### PR TITLE
ENH: API change in ``TransformChain`` - new composition convention

### DIFF
--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from scipy import ndimage as ndi
 
 from nibabel.loadsave import load as _nbload
+from nibabel.affines import from_matvec
 
 from nitransforms.base import (
     ImageGrid,
@@ -217,6 +218,24 @@ should be (0, 0, 0, 1), got %s."""
         raise TransformFileError(
             f"Could not open <{filename}> (formats tried: {', '.join(fmtlist)})."
         )
+
+    @classmethod
+    def from_matvec(cls, mat=None, vec=None, reference=None):
+        """
+        Create an affine from a matrix and translation pair.
+
+        Example
+        -------
+        >>> Affine.from_matvec(vec=(4, 0, 0))  # doctest: +NORMALIZE_WHITESPACE
+        array([[1., 0., 0., 4.],
+               [0., 1., 0., 0.],
+               [0., 0., 1., 0.],
+               [0., 0., 0., 1.]])
+
+        """
+        mat = mat if mat is not None else np.eye(3)
+        vec = vec if vec is not None else np.zeros((3,))
+        return cls(from_matvec(mat, vector=vec), reference=reference)
 
     def __repr__(self):
         """

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -131,8 +131,8 @@ class TransformChain(TransformBase):
             raise TransformError("Cannot apply an empty transforms chain.")
 
         transforms = self.transforms
-        if not inverse:
-            transforms = self.transforms[::-1]
+        if inverse:
+            transforms = list(reversed(self.transforms))
 
         for xfm in transforms:
             x = xfm(x, inverse=inverse)
@@ -157,9 +157,9 @@ class TransformChain(TransformBase):
             xforms = itk.ITKCompositeH5.from_filename(filename)
             for xfmobj in xforms:
                 if isinstance(xfmobj, itk.ITKLinearTransform):
-                    retval.append(Affine(xfmobj.to_ras(), reference=reference))
+                    retval.insert(0, Affine(xfmobj.to_ras(), reference=reference))
                 else:
-                    retval.append(DisplacementsFieldTransform(xfmobj))
+                    retval.insert(0, DisplacementsFieldTransform(xfmobj))
 
             return TransformChain(retval)
 

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -8,6 +8,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Common interface for transforms."""
 from collections.abc import Iterable
+import numpy as np
 
 from .base import (
     TransformBase,
@@ -139,10 +140,19 @@ class TransformChain(TransformBase):
 
         return x
 
-    def asaffine(self):
-        """Combine a succession of linear transforms into one."""
-        retval = self.transforms[-1]
-        for xfm in self.transforms[:-1][::-1]:
+    def asaffine(self, indices=None):
+        """
+        Combine a succession of linear transforms into one.
+
+        Parameters
+        ----------
+        indices : :obj:`numpy.array_like`
+            The indices of the values to extract.
+
+        """
+        affines = self.transforms if indices is None else np.take(self.transforms, indices)
+        retval = affines[0]
+        for xfm in affines[1:]:
             retval @= xfm
         return retval
 

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -74,8 +74,8 @@ class TransformChain(TransformBase):
     @transforms.setter
     def transforms(self, value):
         self._transforms = _as_chain(value)
-        if self.transforms[-1].reference:
-            self.reference = self.transforms[-1].reference
+        if self.transforms[0].reference:
+            self.reference = self.transforms[0].reference
 
     def append(self, x):
         """

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -136,7 +136,7 @@ class TransformChain(TransformBase):
             transforms = list(reversed(self.transforms))
 
         for xfm in transforms:
-            x = xfm(x, inverse=inverse)
+            x = xfm.map(x, inverse=inverse)
 
         return x
 
@@ -156,6 +156,22 @@ class TransformChain(TransformBase):
                [0., 0., 1., 0.],
                [0., 0., 0., 1.]])
 
+        >>> chain = TransformChain(transforms=[
+        ...     Affine.from_matvec(vec=(1, 2, 3)),
+        ...     Affine.from_matvec(mat=[[0, 1, 0], [0, 0, 1], [1, 0, 0]]),
+        ... ])
+        >>> chain.asaffine()
+        array([[0., 1., 0., 2.],
+               [0., 0., 1., 3.],
+               [1., 0., 0., 1.],
+               [0., 0., 0., 1.]])
+
+        >>> np.allclose(
+        ...     chain.map((4, -2, 1)),
+        ...     chain.asaffine().map((4, -2, 1)),
+        ... )
+        True
+
         Parameters
         ----------
         indices : :obj:`numpy.array_like`
@@ -165,7 +181,7 @@ class TransformChain(TransformBase):
         affines = self.transforms if indices is None else np.take(self.transforms, indices)
         retval = affines[0]
         for xfm in affines[1:]:
-            retval @= xfm
+            retval = xfm @ retval
         return retval
 
     @classmethod

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -144,6 +144,18 @@ class TransformChain(TransformBase):
         """
         Combine a succession of linear transforms into one.
 
+        Example
+        ------
+        >>> chain = TransformChain(transforms=[
+        ...     Affine.from_matvec(vec=(2, -10, 3)),
+        ...     Affine.from_matvec(vec=(-2, 10, -3)),
+        ... ])
+        >>> chain.asaffine()
+        array([[1., 0., 0., 0.],
+               [0., 1., 0., 0.],
+               [0., 0., 1., 0.],
+               [0., 0., 0., 1.]])
+
         Parameters
         ----------
         indices : :obj:`numpy.array_like`

--- a/nitransforms/tests/test_manip.py
+++ b/nitransforms/tests/test_manip.py
@@ -69,14 +69,14 @@ def test_collapse_affines(tmp_path, data_path, ext0, ext1, ext2):
     chain = TransformChain(
         [
             Affine.from_filename(
-                data_path / "regressions" / f"from-scanner_to-bold_mode-image.{ext1}",
-                fmt=f"{FMT[ext1]}",
-            ),
-            Affine.from_filename(
                 data_path
                 / "regressions"
                 / f"from-fsnative_to-scanner_mode-image.{ext0}",
                 fmt=f"{FMT[ext0]}",
+            ),
+            Affine.from_filename(
+                data_path / "regressions" / f"from-scanner_to-bold_mode-image.{ext1}",
+                fmt=f"{FMT[ext1]}",
             ),
         ]
     )

--- a/nitransforms/tests/test_manip.py
+++ b/nitransforms/tests/test_manip.py
@@ -69,14 +69,14 @@ def test_collapse_affines(tmp_path, data_path, ext0, ext1, ext2):
     chain = TransformChain(
         [
             Affine.from_filename(
+                data_path / "regressions" / f"from-scanner_to-bold_mode-image.{ext1}",
+                fmt=f"{FMT[ext1]}",
+            ),
+            Affine.from_filename(
                 data_path
                 / "regressions"
                 / f"from-fsnative_to-scanner_mode-image.{ext0}",
                 fmt=f"{FMT[ext0]}",
-            ),
-            Affine.from_filename(
-                data_path / "regressions" / f"from-scanner_to-bold_mode-image.{ext1}",
-                fmt=f"{FMT[ext1]}",
             ),
         ]
     )


### PR DESCRIPTION
This PR makes the ``TransformChain`` class more consistent with the
overall coordinate system, assuming that transforms are chained with the
*points* criteria.

In other words, in the typical setup where we have estimated one
initializing affine and then perhaps two levels of nonlinear
deformations, when calculating the coordinates of a given index in the
reference image, the last nonlinear should be applied first, then the
second, and finally the affine to pull information from the moving
image.

In other words, the chaining (composition) operation works exactly as
a single transformation procedure.

Resolves #81.