### PR TITLE
FIX: Ensure datatype of generated CIFTI2 file in ``TransformBase`` unit test

### DIFF
--- a/nitransforms/tests/test_base.py
+++ b/nitransforms/tests/test_base.py
@@ -113,7 +113,8 @@ def test_TransformBase(monkeypatch, testdata_path, tmpdir):
     gii = nb.gifti.GiftiImage(
         darrays=[
             nb.gifti.GiftiDataArray(
-                data=xfm.reference.ndcoords, intent=nb.nifti1.intent_codes["pointset"]
+                data=xfm.reference.ndcoords.astype("float32"),
+                intent=nb.nifti1.intent_codes["pointset"],
             )
         ]
     )


### PR DESCRIPTION
Make sure the CIFTI2 file in the failing test is created with a ``float32`` data type.

Resolves: #177.