### PR TITLE
ENH: Load ITK's ``.mat`` files with ``Affine``'s loaders

### DIFF
--- a/nitransforms/io/fsl.py
+++ b/nitransforms/io/fsl.py
@@ -109,9 +109,7 @@ class FSLLinearTransformArray(BaseLinearTransformList):
         output_dir = Path(filename).parent
         output_dir.mkdir(exist_ok=True, parents=True)
         for i, xfm in enumerate(self.xforms):
-            (output_dir / ".".join((str(filename), "%03d" % i))).write_text(
-                xfm.to_string()
-            )
+            (output_dir / f"{filename}.{i:03d}").write_text(str(xfm))
 
     def to_ras(self, moving=None, reference=None):
         """Return a nitransforms' internal RAS matrix."""

--- a/nitransforms/io/itk.py
+++ b/nitransforms/io/itk.py
@@ -204,7 +204,14 @@ class ITKLinearTransform(LinearParameters):
         parameters[:3, :3] = vals[:-3].reshape((3, 3))
         parameters[:3, 3] = vals[-3:]
         sa["parameters"] = parameters
-        return tf
+
+        # Try to double-dip and see if there are more transforms
+        try:
+            cls.from_string("\n".join(lines[4:8]))
+        except TransformFileError:
+            return tf
+        else:
+            raise TransformFileError("More than one linear transform found.")
 
 
 class ITKLinearTransformArray(BaseLinearTransformList):

--- a/nitransforms/io/itk.py
+++ b/nitransforms/io/itk.py
@@ -5,7 +5,7 @@ from scipy.io import loadmat as _read_mat, savemat as _save_mat
 from h5py import File as H5File
 from nibabel import Nifti1Header, Nifti1Image
 from nibabel.affines import from_matvec
-from .base import (
+from nitransforms.io.base import (
     BaseLinearTransformList,
     DisplacementsField,
     LinearParameters,

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -230,13 +230,6 @@ should be (0, 0, 0, 1), got %s."""
                 continue
 
             matrix = struct.to_ras(reference=reference, moving=moving)
-
-            # Process matrix
-            if not is_array and np.ndim(matrix) == 3:
-                if np.shape(matrix)[0] != 1:
-                    raise TypeError("Cannot load transform array '%s'" % filename)
-                matrix = matrix[0]
-
             return cls(matrix, reference=reference)
 
         raise TransformFileError(

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -203,8 +203,17 @@ should be (0, 0, 0, 1), got %s."""
         """Create an affine from a transform file."""
         fmtlist = [fmt] if fmt is not None else ("itk", "lta", "afni", "fsl")
 
-        is_array = cls != Affine
+        if fmt is not None and not Path(filename).exists():
+            if fmt != "fsl":
+                raise FileNotFoundError(
+                    f"[Errno 2] No such file or directory: '{filename}'"
+                )
+            elif not Path(f"{filename}.000").exists():
+                raise FileNotFoundError(
+                    f"[Errno 2] No such file or directory: '{filename}[.000]'"
+                )
 
+        is_array = cls != Affine
         errors = []
         for potential_fmt in fmtlist:
             if (potential_fmt == "itk" and Path(filename).suffix == ".mat"):

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -203,17 +203,32 @@ should be (0, 0, 0, 1), got %s."""
         """Create an affine from a transform file."""
         fmtlist = [fmt] if fmt is not None else ("itk", "lta", "afni", "fsl")
 
+        is_array = cls != Affine
+
+        errors = []
         for potential_fmt in fmtlist:
+            if (potential_fmt == "itk" and Path(filename).suffix == ".mat"):
+                is_array = False
+                cls = Affine
+
             try:
-                struct = get_linear_factory(potential_fmt).from_filename(filename)
-                matrix = struct.to_ras(reference=reference, moving=moving)
-                if cls == Affine:
-                    if np.shape(matrix)[0] != 1:
-                        raise TypeError("Cannot load transform array '%s'" % filename)
-                    matrix = matrix[0]
-                return cls(matrix, reference=reference)
-            except (TransformFileError, FileNotFoundError):
+                struct = get_linear_factory(
+                    potential_fmt,
+                    is_array=is_array
+                ).from_filename(filename)
+            except (TransformFileError, FileNotFoundError) as err:
+                errors.append((potential_fmt, err))
                 continue
+
+            matrix = struct.to_ras(reference=reference, moving=moving)
+
+            # Process matrix
+            if not is_array and np.ndim(matrix) == 3:
+                if np.shape(matrix)[0] != 1:
+                    raise TypeError("Cannot load transform array '%s'" % filename)
+                matrix = matrix[0]
+
+            return cls(matrix, reference=reference)
 
         raise TransformFileError(
             f"Could not open <{filename}> (formats tried: {', '.join(fmtlist)})."
@@ -499,6 +514,8 @@ def load(filename, fmt=None, reference=None, moving=None):
     xfm = LinearTransformsMapping.from_filename(
         filename, fmt=fmt, reference=reference, moving=moving
     )
-    if len(xfm) == 1:
-        return xfm[0]
+
+    if isinstance(xfm, LinearTransformsMapping) and len(xfm) == 1:
+        xfm = xfm[0]
+
     return xfm

--- a/nitransforms/tests/test_linear.py
+++ b/nitransforms/tests/test_linear.py
@@ -53,6 +53,12 @@ def test_linear_filenotfound(data_path):
     with pytest.raises(FileNotFoundError):
         nitl.Affine.from_filename("doesnotexist.tfm", fmt="itk")
 
+    with pytest.raises(FileNotFoundError):
+        nitl.LinearTransformsMapping.from_filename("doesnotexist.tfm", fmt="itk")
+
+    with pytest.raises(FileNotFoundError):
+        nitl.LinearTransformsMapping.from_filename("doesnotexist.mat", fmt="fsl")
+
 
 def test_linear_valueerror():
     """Exercise errors in Affine creation."""

--- a/nitransforms/tests/test_linear.py
+++ b/nitransforms/tests/test_linear.py
@@ -44,7 +44,7 @@ def test_linear_typeerrors1(matrix):
 
 def test_linear_typeerrors2(data_path):
     """Exercise errors in Affine creation."""
-    with pytest.raises(TypeError):
+    with pytest.raises(io.TransformFileError):
         nitl.Affine.from_filename(data_path / "itktflist.tfm", fmt="itk")
 
 

--- a/nitransforms/tests/test_linear.py
+++ b/nitransforms/tests/test_linear.py
@@ -48,6 +48,12 @@ def test_linear_typeerrors2(data_path):
         nitl.Affine.from_filename(data_path / "itktflist.tfm", fmt="itk")
 
 
+def test_linear_filenotfound(data_path):
+    """Exercise errors in Affine creation."""
+    with pytest.raises(FileNotFoundError):
+        nitl.Affine.from_filename("doesnotexist.tfm", fmt="itk")
+
+
 def test_linear_valueerror():
     """Exercise errors in Affine creation."""
     with pytest.raises(ValueError):
@@ -83,6 +89,38 @@ def test_loadsave_itk(tmp_path, data_path, testdata_path):
     assert single_xfm == nitl.Affine.from_filename(
         data_path / "affine-LAS.itk.tfm", fmt="itk"
     )
+
+
+@pytest.mark.parametrize(
+    "image_orientation",
+    [
+        "RAS",
+        "LAS",
+        "LPS",
+        "oblique",
+    ],
+)
+def test_itkmat_loadsave(tmpdir, data_path, image_orientation):
+    tmpdir.chdir()
+
+    io.itk.ITKLinearTransform.from_filename(
+        data_path / f"affine-{image_orientation}.itk.tfm"
+    ).to_filename(f"affine-{image_orientation}.itk.mat")
+
+    xfm = nitl.load(data_path / f"affine-{image_orientation}.itk.tfm", fmt="itk")
+    mat1 = nitl.load(f"affine-{image_orientation}.itk.mat", fmt="itk")
+
+    assert xfm == mat1
+
+    mat2 = nitl.Affine.from_filename(f"affine-{image_orientation}.itk.mat", fmt="itk")
+
+    assert xfm == mat2
+
+    mat3 = nitl.LinearTransformsMapping.from_filename(
+        f"affine-{image_orientation}.itk.mat", fmt="itk"
+    )
+
+    assert xfm == mat3
 
 
 @pytest.mark.parametrize("autofmt", (False, True))


### PR DESCRIPTION
Resolves a bug that disabled loading ITK matlab files unless you used the low-level io utility.