### PR TITLE
MNT: Drop Python 3.7 support, test through 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9',  '3.10',  '3.11']
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Build in confined, updated environment and interpolate version
@@ -89,9 +89,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - run: pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,19 +26,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Build in confined, updated environment and interpolate version
+    - name: Build package
       run: |
-        python -m venv /tmp/buildenv
-        source /tmp/buildenv/bin/activate
-        python -m pip install -U setuptools pip wheel twine docutils
-        python setup.py sdist bdist_wheel
-        python -m twine check dist/nitransforms*
+        pipx run build
+    - name: Determine expected version
+      run: |
+        python -m venv /tmp/getversion
+        source /tmp/getversion/bin/activate
+        python -m pip install setuptools_scm
 
         # Interpolate version
         if [[ "$GITHUB_REF" == refs/tags/* ]]; then
           TAG=${GITHUB_REF##*/}
         fi
-        THISVERSION=$( python setup.py --version )
+        THISVERSION=$( python -m setuptools_scm )
         THISVERSION=${TAG:-$THISVERSION}
         echo "Expected VERSION: \"${THISVERSION}\""
         echo "THISVERSION=${THISVERSION}" >> ${GITHUB_ENV}
@@ -47,7 +48,7 @@ jobs:
       run: |
         python -m venv /tmp/install_sdist
         source /tmp/install_sdist/bin/activate
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip
         python -m pip install dist/nitransforms*.tar.gz
         INSTALLED_VERSION=$(python -c 'import nitransforms; print(nitransforms.__version__, end="")')
         echo "VERSION: \"${THISVERSION}\""
@@ -58,7 +59,7 @@ jobs:
       run: |
         python -m venv /tmp/install_wheel
         source /tmp/install_wheel/bin/activate
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip
         python -m pip install dist/nitransforms*.whl
         INSTALLED_VERSION=$(python -c 'import nitransforms; print(nitransforms.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
@@ -94,5 +95,4 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.7
-    - run: pip install flake8
-    - run: flake8 nitransforms/
+    - run: pipx run flake8 nitransforms

--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9',  '3.10',  '3.11']
 
     steps:
     - name: Git settings (pacify DataLad)

--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -33,7 +33,7 @@ jobs:
           python-${{ matrix.python-version }}-
     - name: Install DataLad
       run: |
-        $CONDA/bin/conda install -c conda-forge git-annex datalad pip codecov pytest
+        $CONDA/bin/conda install -c conda-forge git-annex datalad pip pytest
         $CONDA/bin/python -m pip install datalad-osf
 
     - uses: actions/cache@v3
@@ -62,5 +62,6 @@ jobs:
         $CONDA/bin/pytest -v --cov nitransforms --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules nitransforms/
 
     - name: Submit code coverage
-      run: |
-        $CONDA/bin/python -m codecov --flags travis --file cov.xml -e $GITHUB_RUN_NUMBER
+      uses: codecov/codecov-action@v3
+      with:
+        files: cov.xml

--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -19,10 +19,10 @@ jobs:
         git config --global user.name 'NiPreps Bot'
         git config --global user.email 'nipreps@gmail.com'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: conda
       with:
         path: |
@@ -36,7 +36,7 @@ jobs:
         $CONDA/bin/conda install -c conda-forge git-annex datalad pip codecov pytest
         $CONDA/bin/python -m pip install datalad-osf
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ${{ env.TEST_DATA_HOME }}
         key: data-cache-v2
@@ -53,7 +53,7 @@ jobs:
         $CONDA/bin/datalad update --merge -d nitransforms-tests/
         $CONDA/bin/datalad get -d nitransforms-tests/
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install minimal dependencies
       run: |
         $CONDA/bin/pip install .[tests]

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -45,7 +45,7 @@ def cli_apply(pargs):
         cval=pargs.cval,
         prefilter=pargs.prefilter,
     )
-    moved.to_filename(pargs.out or "nt_{}".format(os.path.basename(pargs.moving)))
+    moved.to_filename(pargs.out or f"nt_{os.path.basename(pargs.moving)}")
 
 
 def get_parser():

--- a/nitransforms/io/lta.py
+++ b/nitransforms/io/lta.py
@@ -176,7 +176,7 @@ class FSLinearTransform(LinearTransformStruct):
             return
 
         raise NotImplementedError(
-            "Converting {0} to {1} is not yet available".format(
+            "Converting {} to {} is not yet available".format(
                 transform_codes.label[current], transform_codes.label[new_type]
             )
         )
@@ -334,7 +334,7 @@ class FSLinearTransformArray(BaseLinearTransformList):
         code = int(self["type"])
         header = [
             "# LTA-array file created by NiTransforms",
-            "type      = {} # {}".format(code, transform_codes.label[code]),
+            f"type      = {code} # {transform_codes.label[code]}",
             "nxforms   = {}".format(self["nxforms"]),
         ]
         xforms = [xfm.to_string(partial=True) for xfm in self._xforms]

--- a/nitransforms/nonlinear.py
+++ b/nitransforms/nonlinear.py
@@ -241,7 +241,7 @@ class BSplineFieldTransform(TransformBase):
 
     def __init__(self, coefficients, reference=None, order=3):
         """Create a smooth deformation field using B-Spline basis."""
-        super(BSplineFieldTransform, self).__init__()
+        super().__init__()
         self._order = order
 
         coefficients = _ensure_image(coefficients)

--- a/nitransforms/tests/test_io.py
+++ b/nitransforms/tests/test_io.py
@@ -204,7 +204,7 @@ def test_Linear_common(tmpdir, data_path, sw, image_orientation, get_testdata):
     with pytest.raises(TransformFileError):
         factory.from_string("")
 
-    fname = "affine-%s.%s%s" % (image_orientation, sw, ext)
+    fname = f"affine-{image_orientation}.{sw}{ext}"
 
     # Test the transform loaders are implemented
     xfm = factory.from_filename(data_path / fname)
@@ -262,7 +262,7 @@ def test_LinearList_common(tmpdir, data_path, sw, image_orientation, get_testdat
 
     tflist1 = factory(mats)
 
-    fname = "affine-%s.%s%s" % (image_orientation, sw, ext)
+    fname = f"affine-{image_orientation}.{sw}{ext}"
 
     with pytest.raises(FileNotFoundError):
         factory.from_filename(fname)
@@ -305,7 +305,7 @@ def test_ITKLinearTransform(tmpdir, testdata_path):
 
     # Test to_filename(textfiles)
     itkxfm.to_filename("textfile.tfm")
-    with open("textfile.tfm", "r") as f:
+    with open("textfile.tfm") as f:
         itkxfm2 = itk.ITKLinearTransform.from_fileobj(f)
     assert np.allclose(itkxfm["parameters"], itkxfm2["parameters"])
 

--- a/nitransforms/tests/test_linear.py
+++ b/nitransforms/tests/test_linear.py
@@ -226,7 +226,7 @@ def test_linear_save(tmpdir, data_path, get_testdata, image_orientation, sw_tool
     elif sw_tool == "fs":
         ext = ".lta"
 
-    xfm_fname1 = "M.%s%s" % (sw_tool, ext)
+    xfm_fname1 = f"M.{sw_tool}{ext}"
     xfm.to_filename(xfm_fname1, fmt=sw_tool)
 
     xfm_fname2 = str(data_path / "affine-%s.%s%s") % (image_orientation, sw_tool, ext)
@@ -257,7 +257,7 @@ def test_apply_linear_transform(tmpdir, get_testdata, get_testmask, image_orient
     msk.to_filename("mask.nii.gz")
 
     # Write out transform file (software-dependent)
-    xfm_fname = "M.%s%s" % (sw_tool, ext)
+    xfm_fname = f"M.{sw_tool}{ext}"
     # Change reference dataset for AFNI & oblique
     if (sw_tool, image_orientation) == ("afni", "oblique"):
         io.afni.AFNILinearTransform.from_ras(
@@ -278,7 +278,7 @@ def test_apply_linear_transform(tmpdir, get_testdata, get_testmask, image_orient
     # skip test if command is not available on host
     exe = cmd.split(" ", 1)[0]
     if not shutil.which(exe):
-        pytest.skip("Command {} not found on host".format(exe))
+        pytest.skip(f"Command {exe} not found on host")
 
     # resample mask
     exit_code = check_call([cmd], shell=True)

--- a/nitransforms/tests/test_nonlinear.py
+++ b/nitransforms/tests/test_nonlinear.py
@@ -158,7 +158,7 @@ def test_displacements_field1(
     # skip test if command is not available on host
     exe = cmd.split(" ", 1)[0]
     if not shutil.which(exe):
-        pytest.skip("Command {} not found on host".format(exe))
+        pytest.skip(f"Command {exe} not found on host")
 
     # resample mask
     exit_code = check_call([cmd], shell=True)
@@ -219,7 +219,7 @@ def test_displacements_field2(tmp_path, testdata_path, sw_tool):
     # skip test if command is not available on host
     exe = cmd.split(" ", 1)[0]
     if not shutil.which(exe):
-        pytest.skip("Command {} not found on host".format(exe))
+        pytest.skip(f"Command {exe} not found on host")
 
     exit_code = check_call([cmd], shell=True)
     assert exit_code == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive"]
+requires = ["setuptools >= 45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "nitransforms/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,10 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 description = NiTransforms -- Neuroimaging spatial transforms in Python.
 license = MIT License
 long_description = file:README.md
@@ -20,7 +21,7 @@ project_urls =
 url = https://github.com/nipy/nitransforms
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     numpy >= 1.21.0
     scipy >= 1.6.0


### PR DESCRIPTION
Some additional cleanups. Not touching CircleCI right now, as it doesn't seem broken and it's at least testing 3.9.

Also ran `pyupgrade --py38-plus`. Automated housekeeping seems like a win.