### PR TITLE
FIX: Postpone coordinate mapping on linear array transforms

### DIFF
--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -458,7 +458,7 @@ class LinearTransformsMapping(Affine):
         output_dtype = output_dtype or input_dtype
 
         # Prepare physical coordinates of input (grid, points)
-        xcoords = _ref.ndcoords.astype("f4")
+        xcoords = _ref.ndcoords.astype("f4").T
 
         # Invert target's (moving) affine once
         ras2vox = ~Affine(spatialimage.affine)
@@ -472,7 +472,7 @@ class LinearTransformsMapping(Affine):
         # Order F ensures individual volumes are contiguous in memory
         # Also matches NIfTI, making final save more efficient
         resampled = np.zeros(
-            (xcoords.T.shape[0], len(self)), dtype=output_dtype, order="F"
+            (xcoords.shape[0], len(self)), dtype=output_dtype, order="F"
         )
 
         dataobj = (
@@ -483,7 +483,7 @@ class LinearTransformsMapping(Affine):
 
         for t, xfm_t in enumerate(self):
             # Map the input coordinates on to timepoint t of the target (moving)
-            ycoords = xfm_t.map(xcoords.T)[..., : _ref.ndim]
+            ycoords = xfm_t.map(xcoords)[..., : _ref.ndim]
 
             # Calculate corresponding voxel coordinates
             yvoxels = ras2vox.map(ycoords)[..., : _ref.ndim]

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -14,6 +14,7 @@ from scipy import ndimage as ndi
 
 from nibabel.loadsave import load as _nbload
 from nibabel.affines import from_matvec
+from nibabel.arrayproxy import get_obj_dtype
 
 from nitransforms.base import (
     ImageGrid,
@@ -448,7 +449,7 @@ class LinearTransformsMapping(Affine):
             spatialimage = _nbload(str(spatialimage))
 
         # Avoid opening the data array just yet
-        input_dtype = nb.arrayproxy.get_obj_dtype(spatialimage.dataobj)
+        input_dtype = get_obj_dtype(spatialimage.dataobj)
         output_dtype = output_dtype or input_dtype
 
         # Prepare physical coordinates of input (grid, points)

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -492,7 +492,7 @@ class LinearTransformsMapping(Affine):
                 (
                     dataobj
                     if dataobj is not None
-                    else np.asanyarray(spatialimage.dataobj[..., t], dtype=input_dtype)
+                    else spatialimage.dataobj[..., t].astype(input_dtype, copy=False)
                 ),
                 yvoxels.T,
                 output=output_dtype,

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -448,7 +448,7 @@ class LinearTransformsMapping(Affine):
             spatialimage = _nbload(str(spatialimage))
 
         # Avoid opening the data array just yet
-        input_dtype = spatialimage.header.get_data_dtype()
+        input_dtype = nb.arrayproxy.get_obj_dtype(spatialimage.dataobj)
         output_dtype = output_dtype or input_dtype
 
         # Prepare physical coordinates of input (grid, points)

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -217,14 +217,13 @@ should be (0, 0, 0, 1), got %s."""
         is_array = cls != Affine
         errors = []
         for potential_fmt in fmtlist:
-            if (potential_fmt == "itk" and Path(filename).suffix == ".mat"):
+            if potential_fmt == "itk" and Path(filename).suffix == ".mat":
                 is_array = False
                 cls = Affine
 
             try:
                 struct = get_linear_factory(
-                    potential_fmt,
-                    is_array=is_array
+                    potential_fmt, is_array=is_array
                 ).from_filename(filename)
             except (TransformFileError, FileNotFoundError) as err:
                 errors.append((potential_fmt, err))
@@ -491,7 +490,8 @@ class LinearTransformsMapping(Affine):
             # Interpolate
             resampled[..., t] = ndi.map_coordinates(
                 (
-                    dataobj if dataobj is not None 
+                    dataobj
+                    if dataobj is not None
                     else np.asanyarray(spatialimage.dataobj[..., t], dtype=input_dtype)
                 ),
                 yvoxels.T,
@@ -503,10 +503,8 @@ class LinearTransformsMapping(Affine):
             )
 
         if isinstance(_ref, ImageGrid):  # If reference is grid, reshape
-            newdata = resampled.reshape(_ref.shape + (len(self), ))
-            moved = spatialimage.__class__(
-                newdata, _ref.affine, spatialimage.header
-            )
+            newdata = resampled.reshape(_ref.shape + (len(self),))
+            moved = spatialimage.__class__(newdata, _ref.affine, spatialimage.header)
             moved.header.set_data_dtype(output_dtype)
             return moved
 


### PR DESCRIPTION
This PR transforms the coordinates of the reference into the moving image for each timepoint separately, effectively minimizing the memory footprint.

Resolves: #173.