### PR TITLE
FIX: Load ITK fields from H5 correctly

### DIFF
--- a/nitransforms/io/itk.py
+++ b/nitransforms/io/itk.py
@@ -423,7 +423,7 @@ class ITKCompositeH5:
                 hdr.set_data_dtype("float")
 
                 xfm_list.append(
-                    Nifti1Image(field.astype("float"), affine @ LPS, hdr)
+                    Nifti1Image(field.astype("float"), LPS @ affine, hdr)
                 )
                 continue
 


### PR DESCRIPTION
Ports nipreps/fmriprep#3300 to nitransforms.

I've gotten ANTs to generate a warp field with a non-cardinal rotation matrix and anistropic spacing:

![image](https://github.com/nipy/nitransforms/assets/83442/7280d82b-c655-4369-b7d4-a90d6cff23b4)

Need to verify that we're raveling the fixed parameters in the correct order. Numpy defaults to C.