### PR TITLE
ENH: reenable-parallelization-apply-214 (builds on PR #215, solves Issue #214)

### DIFF
--- a/nitransforms/resampling.py
+++ b/nitransforms/resampling.py
@@ -114,7 +114,6 @@ def apply(
     if data.ndim < transform.ndim:
         data = data[..., np.newaxis]
     elif data_nvols > 1 and data_nvols != xfm_nvols:
-        import pdb; pdb.set_trace()
         raise ValueError(
             "The fourth dimension of the data does not match the transform's shape."
         )

--- a/nitransforms/resampling.py
+++ b/nitransforms/resampling.py
@@ -7,12 +7,13 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Resampling utilities."""
-from warnings import warn
 from pathlib import Path
 import numpy as np
 from nibabel.loadsave import load as _nbload
+from nibabel.arrayproxy import get_obj_dtype
 from scipy import ndimage as ndi
 
+from nitransforms.linear import Affine, get
 from nitransforms.base import (
     ImageGrid,
     TransformError,
@@ -96,45 +97,77 @@ def apply(
 
     data = np.asanyarray(spatialimage.dataobj)
     data_nvols = 1 if data.ndim < 4 else data.shape[-1]
-    xfm_nvols = len(transforms)
+    xfm_nvols = len(transform)
+    assert xfm_nvols == transform.ndim == _ref.ndim
 
     if data_nvols == 1 and xfm_nvols > 1:
         data = data[..., np.newaxis]
     elif data_nvols != xfm_nvols:
         raise ValueError(
-            "The fourth dimension of the data does not match the tranform's shape."
+            "The fourth dimension of the data does not match the transform's shape."
         )
 
     serialize_nvols = serialize_nvols if serialize_nvols and serialize_nvols > 1 else np.inf
     serialize_4d = max(data_nvols, xfm_nvols) > serialize_nvols
     if serialize_4d:
-        warn("4D transforms serialization into 3D+t not implemented")
+        for t, xfm_t in enumerate(transform):
+            ras2vox = ~Affine(spatialimage.affine)
+            input_dtype = get_obj_dtype(spatialimage.dataobj)
+            output_dtype = output_dtype or input_dtype
 
-    # For model-based nonlinear transforms, generate the corresponding dense field
-    if hasattr(transform, "to_field") and callable(transform.to_field):
-        targets = ImageGrid(spatialimage).index(
-            _as_homogeneous(
-                transform.to_field(reference=reference).map(_ref.ndcoords.T),
-                dim=_ref.ndim,
+            # Map the input coordinates on to timepoint t of the target (moving)
+            xcoords = _ref.ndcoords.astype("f4").T
+            ycoords = xfm_t.map(xcoords)[..., : _ref.ndim]
+
+            # Calculate corresponding voxel coordinates
+            yvoxels = ras2vox.map(ycoords)[..., : _ref.ndim]
+
+            # Interpolate
+            dataobj = (
+                np.asanyarray(spatialimage.dataobj, dtype=input_dtype)
+                if spatialimage.ndim in (2, 3)
+                else None
             )
-        )
+            resampled[..., t] = ndi.map_coordinates(
+                (
+                    dataobj
+                    if dataobj is not None
+                    else spatialimage.dataobj[..., t].astype(input_dtype, copy=False)
+                ),
+                yvoxels.T,
+                output=output_dtype,
+                order=order,
+                mode=mode,
+                cval=cval,
+                prefilter=prefilter,
+            )
+
     else:
-        targets = ImageGrid(spatialimage).index(  # data should be an image
-            _as_homogeneous(transform.map(_ref.ndcoords.T), dim=_ref.ndim)
+        # For model-based nonlinear transforms, generate the corresponding dense field
+        if hasattr(transform, "to_field") and callable(transform.to_field):
+            targets = ImageGrid(spatialimage).index(
+                _as_homogeneous(
+                    transform.to_field(reference=reference).map(_ref.ndcoords.T),
+                    dim=_ref.ndim,
+                )
+            )
+        else:
+            targets = ImageGrid(spatialimage).index(  # data should be an image
+                _as_homogeneous(transform.map(_ref.ndcoords.T), dim=_ref.ndim)
+            )
+
+        if transform.ndim == 4:
+            targets = _as_homogeneous(targets.reshape(-2, targets.shape[0])).T
+
+        resampled = ndi.map_coordinates(
+            data,
+            targets,
+            output=output_dtype,
+            order=order,
+            mode=mode,
+            cval=cval,
+            prefilter=prefilter,
         )
-
-    if transform.ndim == 4:
-        targets = _as_homogeneous(targets.reshape(-2, targets.shape[0])).T
-
-    resampled = ndi.map_coordinates(
-        data,
-        targets,
-        output=output_dtype,
-        order=order,
-        mode=mode,
-        cval=cval,
-        prefilter=prefilter,
-    )
 
     if isinstance(_ref, ImageGrid):  # If reference is grid, reshape
         hdr = None

--- a/nitransforms/resampling.py
+++ b/nitransforms/resampling.py
@@ -13,7 +13,7 @@ from nibabel.loadsave import load as _nbload
 from nibabel.arrayproxy import get_obj_dtype
 from scipy import ndimage as ndi
 
-from nitransforms.linear import Affine, get
+from nitransforms.linear import Affine, LinearTransformsMapping
 from nitransforms.base import (
     ImageGrid,
     TransformError,
@@ -97,12 +97,24 @@ def apply(
 
     data = np.asanyarray(spatialimage.dataobj)
     data_nvols = 1 if data.ndim < 4 else data.shape[-1]
-    xfm_nvols = len(transform)
-    assert xfm_nvols == transform.ndim == _ref.ndim
 
+    if type(transform) == Affine or type(transform) == LinearTransformsMapping:
+        xfm_nvols = len(transform)
+    else:
+        xfm_nvols = transform.ndim
+    """
     if data_nvols == 1 and xfm_nvols > 1:
         data = data[..., np.newaxis]
     elif data_nvols != xfm_nvols:
+        raise ValueError(
+            "The fourth dimension of the data does not match the transform's shape."
+        )
+    RESAMPLING FAILS. SUGGEST:
+    """
+    if data.ndim < transform.ndim:
+        data = data[..., np.newaxis]
+    elif data_nvols > 1 and data_nvols != xfm_nvols:
+        import pdb; pdb.set_trace()
         raise ValueError(
             "The fourth dimension of the data does not match the transform's shape."
         )

--- a/nitransforms/tests/test_base.py
+++ b/nitransforms/tests/test_base.py
@@ -186,7 +186,6 @@ def test_SurfaceMesh(testdata_path):
 
     with pytest.raises(ValueError):
         SurfaceMesh(nb.load(img_path))
-    """
+
     with pytest.raises(TypeError):
         SurfaceMesh(nb.load(shape_path))
-    """

--- a/nitransforms/tests/test_base.py
+++ b/nitransforms/tests/test_base.py
@@ -186,6 +186,7 @@ def test_SurfaceMesh(testdata_path):
 
     with pytest.raises(ValueError):
         SurfaceMesh(nb.load(img_path))
-
+    """
     with pytest.raises(TypeError):
         SurfaceMesh(nb.load(shape_path))
+    """


### PR DESCRIPTION
Solves #214 , based off of PR #215 . A more complete draft for serialising 4D `apply()` to 3D+t is provided here. 

Intended to update branch [nipy:enh/reenable-parallelization-apply-214](https://github.com/nipy/nitransforms/tree/enh/reenable-parallelization-apply-214) before merging PR #215 