### PR TITLE
MAINT: Update ANTs' pinnings

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -12,8 +12,8 @@ dependencies:
   - mkl-service=2.4.0
   # git-annex for templateflow users with DataLad superdatasets
   - git-annex=*=alldep*
-  # ANTs is linked against libitk 5.3 but does not pin the version
-  - libitk=5.3
+  # ANTs 2.5.3 is linked against libitk 5.4 - let's pin both there
+  - libitk=5.4
   # Base scientific python stack; required by FSL, so pinned here
   - numpy=1.26
   - scipy=1.11
@@ -28,7 +28,7 @@ dependencies:
   - graphviz=9.0
   - pandoc=3.1
   # Workflow dependencies: ANTs
-  - ants=2.5
+  - ants=2.5.3
   # Workflow dependencies: FSL (versions pinned in 6.0.7.7)
   - fsl-bet2=2111.4
   - fsl-flirt=2111.2


### PR DESCRIPTION
Before 2.5.3, conda would install the latest ITK (5.4 at the time of writing) but ants was linked against 5.3 and didn't pin that dependency.

In 2.5.3, ants was built and linked against 5.4 and I'm unaware of whether they properly pinned the dependency. Either way, this commit fixes both to 2.5.3 and 5.4.