### PR TITLE
FIX: Use standard library `pathlib`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     scipy >= 1.6.0
     nibabel >= 3.0
     h5py
-    pathlib
 test_requires =
     pytest
     pytest-cov


### PR DESCRIPTION
With https://github.com/nipy/nitransforms/blob/f69faaf44a9cab39141df6f546394e862ed408d2/setup.cfg#L24 and [`pathlib` incorporated into the standard Python library](https://docs.python.org/3.8/library/pathlib.html) in v3.4, we should rely on the `pathlib` in the standard Python library, not [the unmaintained `pathlib` on PyPI intended for Python < 3.4](https://pypi.org/project/pathlib/).

Related: https://github.com/nipy/nitransforms/pull/203#discussion_r1747586808, https://github.com/nipy/nitransforms/pull/203#issuecomment-2334693880