### PR TITLE
FIX: Do not treat iterable transforms as iterables of transforms when adding to a chain

### DIFF
--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -213,6 +213,8 @@ def _as_chain(x):
     """Convert a value into a transform chain."""
     if isinstance(x, TransformChain):
         return x.transforms
+    if isinstance(x, TransformBase):
+        return [x]
     if isinstance(x, Iterable):
         return list(x)
     return [x]

--- a/nitransforms/tests/test_linear.py
+++ b/nitransforms/tests/test_linear.py
@@ -82,6 +82,20 @@ def test_loadsave_itk(tmp_path, data_path, testdata_path):
     )
 
 
+def test_mapping_chain(data_path):
+    xfm = nitl.load(data_path / "itktflist2.tfm", fmt="itk")
+    xfm = nitl.load(data_path / "itktflist2.tfm", fmt="itk")
+    assert len(xfm) == 9
+
+    # Addiition produces a chain
+    chain = xfm + xfm
+    # Length now means number of transforms, not number of affines in one transform
+    assert len(chain) == 2
+    # Just because a LinearTransformsMapping is iterable does not mean we decompose it
+    chain += xfm
+    assert len(chain) == 3
+
+
 @pytest.mark.parametrize(
     "image_orientation",
     [


### PR DESCRIPTION
I believe 97727104 caused `TransforrmChain` to start treating `LinearTransformMapping`s as `Iterable`s to decompose. Thus, I was getting transform chains 303 transforms long instead of 4 long.

Here is a regression test that fails before the patch and passes after the patch.

I believe this resolves the issues in fMRIPrep/fMRIPost.

cc @tsalo