### PR TITLE
fix: Remove pkg_resources dependency

### DIFF
--- a/nitransforms/__init__.py
+++ b/nitransforms/__init__.py
@@ -24,14 +24,7 @@ from .manip import TransformChain
 try:
     from ._version import __version__
 except ModuleNotFoundError:
-    from pkg_resources import get_distribution, DistributionNotFound
-
-    try:
-        __version__ = get_distribution("nitransforms").version
-    except DistributionNotFound:
-        __version__ = "unknown"
-    del get_distribution
-    del DistributionNotFound
+    __version__ = "0+unknown"
 
 __packagename__ = "nitransforms"
 __copyright__ = "Copyright (c) 2021 The NiPy developers"

--- a/nitransforms/tests/test_version.py
+++ b/nitransforms/tests/test_version.py
@@ -1,14 +1,7 @@
 """Test _version.py."""
 import sys
-from collections import namedtuple
 from importlib import reload
-import pytest
 import nitransforms
-
-try:
-    from pkg_resources import DistributionNotFound
-except ImportError:
-    pytest.skip(allow_module_level=True)
 
 
 def test_version_scm0(monkeypatch):
@@ -22,26 +15,9 @@ def test_version_scm0(monkeypatch):
     assert nitransforms.__version__ == "10.0.0"
 
 
-def test_version_scm1(monkeypatch):
-    """Retrieve the version via pkg_resources."""
-    monkeypatch.setitem(sys.modules, "nitransforms._version", None)
-
-    def _dist(name):
-        Distribution = namedtuple("Distribution", ["name", "version"])
-        return Distribution(name, "success")
-
-    monkeypatch.setattr("pkg_resources.get_distribution", _dist)
-    reload(nitransforms)
-    assert nitransforms.__version__ == "success"
-
-
-def test_version_scm2(monkeypatch):
+def test_version_fallback(monkeypatch):
     """Check version could not be interpolated."""
     monkeypatch.setitem(sys.modules, "nitransforms._version", None)
 
-    def _raise(name):
-        raise DistributionNotFound("No get_distribution mock")
-
-    monkeypatch.setattr("pkg_resources.get_distribution", _raise)
     reload(nitransforms)
-    assert nitransforms.__version__ == "unknown"
+    assert nitransforms.__version__ == "0+unknown"


### PR DESCRIPTION
There is no reasonable case where a user has pkg_resources-accessible metadata (or importlib-metadata) and does not have a `_version.py` file.

Instead of replacing with importlib-metadata, I'm just skipping ahead to the hard-coded "unknown", using `0+unknown` to satisfy PEP440.

There may be a very rare case where someone makes an editable installation and borks their directory, but knowing what the version was when they installed it won't help us a lot there.