### PR TITLE
ENH: Allow ingestion of alternatively grouped CompositeH5s

### DIFF
--- a/nitransforms/io/itk.py
+++ b/nitransforms/io/itk.py
@@ -383,12 +383,20 @@ class ITKCompositeH5:
         xfm_list = []
         h5group = fileobj["TransformGroup"]
         typo_fallback = "Transform"
+
+        start_idx = 1
+        for i, group in enumerate(h5group):
+            found = h5group[group].get(f'{typo_fallback}Parameters', None)
+            if found is not None:
+                start_idx = i
+                break
+
         try:
-            h5group["1"][f"{typo_fallback}Parameters"]
+            h5group[f'{start_idx}'][f"{typo_fallback}Parameters"]
         except KeyError:
             typo_fallback = "Tranform"
 
-        for xfm in list(h5group.values())[1:]:
+        for xfm in list(h5group.values())[start_idx:]:
             if xfm["TransformType"][0].startswith(b"AffineTransform"):
                 _params = np.asanyarray(xfm[f"{typo_fallback}Parameters"])
                 xfm_list.append(


### PR DESCRIPTION
`ITKCompositeH5` is quite rigid ATM, bypassing the first H5 group entirely. This can be fine in some cases, but I have a transform containing a single displacement field (generated from a composite transform and reference image) which is not being read.

This PR successfully loads the DenseFieldTransform. If this looks good, can work on tests.