### PR TITLE
Patch for crash when applying 3D transform to 4D image

### DIFF
--- a/nitransforms/resampling.py
+++ b/nitransforms/resampling.py
@@ -108,7 +108,7 @@ async def _apply_serial(
     semaphore = asyncio.Semaphore(max_concurrent)
 
     for t in range(n_resamplings):
-        xfm_t = transform if n_resamplings == 1 else transform[t]
+        xfm_t = transform if (n_resamplings == 1 or transform.ndim < 4) else transform[t]
 
         if targets is None:
             targets = ImageGrid(spatialimage).index(  # data should be an image
@@ -270,7 +270,7 @@ def apply(
         # Order F ensures individual volumes are contiguous in memory
         # Also matches NIfTI, making final save more efficient
         resampled = np.zeros(
-            (len(ref_ndcoords), len(transform)), dtype=input_dtype, order="F"
+            (len(ref_ndcoords), n_resamplings), dtype=input_dtype, order="F"
         )
 
         resampled = asyncio.run(


### PR DESCRIPTION
When applying a 3D transform to a 4D image (intended: applying the same transform to every time slice), I get the following crash (relevant traceback only):
```
  File "/home/corys/parcellate/parcellate/model.py", line 253, in sample
    atlas_nii = nt.resampling.apply(
  File "/home/corys/anaconda3/envs/meg/lib/python3.9/site-packages/nitransforms/resampling.py", line 277, in apply
    resampled = asyncio.run(
  File "/home/corys/anaconda3/envs/meg/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/corys/anaconda3/envs/meg/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/home/corys/anaconda3/envs/meg/lib/python3.9/site-packages/nitransforms/resampling.py", line 111, in _apply_serial
    xfm_t = transform if n_resamplings == 1 else transform[t]
  File "/home/corys/anaconda3/envs/meg/lib/python3.9/site-packages/nitransforms/manip.py", line 64, in __getitem__
    return self.transforms[i]
IndexError: list index out of range
```
This patch tries to catch this use case by avoiding indexing into `self.transform` when the transform is 3D.