### PR TITLE
Configure coverage to omit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,17 @@ doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"
 filterwarnings = ["ignore::DeprecationWarning"]
 junit_family = "xunit2"
+
+[tool.coverage.run]
+branch = true
+omit = [
+    "*/tests/*",
+    "nitransforms/conftest.py",
+    "nitransforms/patched.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "raise NotImplementedError",
+    "warnings\\.warn",
+]


### PR DESCRIPTION
## Summary
- add a `[tool.coverage]` section in `pyproject.toml` so that test files are not
  included in coverage reports

## Testing
- `pip install -e .[tests]`
- `TEST_DATA_HOME=/tmp/testdata pytest -q` *(fails: FileNotFoundError for someones_bspline_coefficients.nii.gz)*

------
https://chatgpt.com/codex/tasks/task_e_6879d623d50c83308df8c9faaad659fb