### PR TITLE
FIX: Broken 4D resampling

### DIFF
--- a/nitransforms/tests/test_resampling.py
+++ b/nitransforms/tests/test_resampling.py
@@ -365,7 +365,8 @@ def test_LinearTransformsMapping_apply(
         )
 
 
-def test_apply_serialized_4d_multiple_targets():
+@pytest.mark.parametrize("serialize_4d", [True, False])
+def test_apply_4d(serialize_4d):
     """Regression test for per-volume transforms with serialized resampling."""
     nvols = 9
     shape = (10, 5, 5)
@@ -379,9 +380,11 @@ def test_apply_serialized_4d_multiple_targets():
         mat[0, 3] = i
         transforms.append(nitl.Affine(mat))
 
-    xfm = nitl.LinearTransformsMapping(transforms, reference=img)
-    moved = apply(xfm, img, order=0)
+    extraparams = {} if serialize_4d else {"serialize_nvols": nvols + 1}
 
+    xfm = nitl.LinearTransformsMapping(transforms, reference=img)
+
+    moved = apply(xfm, img, order=0, **extraparams)
     data = np.asanyarray(moved.dataobj)
     idxs = [tuple(np.argwhere(data[..., i])[0]) for i in range(nvols)]
     assert idxs == [(9 - i, 2, 2) for i in range(nvols)]


### PR DESCRIPTION
## Summary

Resolves several issues in 4D transformations, happening both in "serialized" mode (iterating over 3D volumes) as well as "all-at-once" (interpolating on 4D coordinates). The PR was initiated with codex, generating a new test case that reproduced the problem (it's a small image with only one voxel set to 1, and the transform is a translation along the i-axis of 1 voxel per timepoint (i.e., the voxel moves from one extreme to the other along X in space).

## Issues found:

- The serialized mode was not properly initiating the interpolation targets. Their calculation has been made more general and works for both operation modes (serialized, all-at-once).
- The all-at-once was generating nonsensical targets, reshapings were just fitting the shape of the targets array to what map_coordinates wants, but did not make any sense.

Both issues have been now resolved and the new test exercises both.