### PR TITLE
ENH: Add X5 support of nonlinear transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,12 @@ A new major release with critical updates.
 The new release includes a critical hotfix for 4D resamplings.
 The second major improvement is the inclusion of a first implementation of the X5 format (BIDS).
 The X5 implementation is currently restricted to reading/writing of linear transforms.
-It now supports nonlinear transforms as well.
 
 CHANGES
 -------
 * FIX: Broken 4D resampling by @oesteban in https://github.com/nipy/nitransforms/pull/247
 * ENH: Loading of X5 (linear) transforms by @oesteban in https://github.com/nipy/nitransforms/pull/243
 * ENH: Implement X5 representation and output to filesystem by @oesteban in https://github.com/nipy/nitransforms/pull/241
-* ENH: Support reading and writing of nonlinear transforms in X5
 * DOC: Fix references to ``os.PathLike`` by @oesteban in https://github.com/nipy/nitransforms/pull/242
 * MNT: Increase coverage by testing edge cases and adding docstrings by @oesteban in https://github.com/nipy/nitransforms/pull/248
 * MNT: Refactor io/lta to reduce one partial line by @oesteban in https://github.com/nipy/nitransforms/pull/246

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,14 @@ A new major release with critical updates.
 The new release includes a critical hotfix for 4D resamplings.
 The second major improvement is the inclusion of a first implementation of the X5 format (BIDS).
 The X5 implementation is currently restricted to reading/writing of linear transforms.
+It now supports nonlinear transforms as well.
 
 CHANGES
 -------
 * FIX: Broken 4D resampling by @oesteban in https://github.com/nipy/nitransforms/pull/247
 * ENH: Loading of X5 (linear) transforms by @oesteban in https://github.com/nipy/nitransforms/pull/243
 * ENH: Implement X5 representation and output to filesystem by @oesteban in https://github.com/nipy/nitransforms/pull/241
+* ENH: Support reading and writing of nonlinear transforms in X5
 * DOC: Fix references to ``os.PathLike`` by @oesteban in https://github.com/nipy/nitransforms/pull/242
 * MNT: Increase coverage by testing edge cases and adding docstrings by @oesteban in https://github.com/nipy/nitransforms/pull/248
 * MNT: Refactor io/lta to reduce one partial line by @oesteban in https://github.com/nipy/nitransforms/pull/246

--- a/nitransforms/io/x5.py
+++ b/nitransforms/io/x5.py
@@ -73,11 +73,11 @@ class X5Transform:
     For parametric models it is generally possible to obtain it analytically, so this dataset
     could not be as useful in that case.
     """
-    # additional_parameters: Optional[np.ndarray] = None
-    # AdditionalParameters is empty in the draft spec - ignore for now.
-    # Only documentation ATM is for SubType:
-    # The SubType setting enables setting the additional parameters on a dataset called
-    # "AdditionalParameters" that hangs directly from this transform node.
+    additional_parameters: Optional[np.ndarray] = None
+    """
+    An OPTIONAL field to store additional parameters, depending on the SubType of the
+    transform.
+    """
     array_length: int = 1
     """Undocumented field in the draft to enable a single transform group for 4D transforms."""
 
@@ -130,11 +130,10 @@ def to_filename(fname: str | Path, x5_list: List[X5Transform]):
                 g.create_dataset("Inverse", data=node.inverse)
             if node.jacobian is not None:
                 g.create_dataset("Jacobian", data=node.jacobian)
-            # Disabled until we need SubType and AdditionalParameters
-            # if node.additional_parameters is not None:
-            #     g.create_dataset(
-            #         "AdditionalParameters", data=node.additional_parameters
-            #     )
+            if node.additional_parameters is not None:
+                g.create_dataset(
+                    "AdditionalParameters", data=node.additional_parameters
+                )
     return fname
 
 
@@ -174,6 +173,9 @@ def _read_x5_group(node) -> X5Transform:
         inverse=np.asarray(node["Inverse"]) if "Inverse" in node else None,
         jacobian=np.asarray(node["Jacobian"]) if "Jacobian" in node else None,
         array_length=int(node.attrs.get("ArrayLength", 1)),
+        additional_parameters=np.asarray(node["AdditionalParameters"])
+        if "AdditionalParameters" in node
+        else None,
     )
 
     if "Domain" in node:

--- a/nitransforms/nonlinear.py
+++ b/nitransforms/nonlinear.py
@@ -7,6 +7,7 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Nonlinear transforms."""
+
 import warnings
 from functools import partial
 from collections import namedtuple
@@ -22,6 +23,12 @@ from nitransforms.base import (
     _as_homogeneous,
 )
 from scipy.ndimage import map_coordinates
+
+# Avoids circular imports
+try:
+    from nitransforms._version import __version__
+except ModuleNotFoundError:  # pragma: no cover
+    __version__ = "0+unknown"
 
 
 class DenseFieldTransform(TransformBase):
@@ -230,14 +237,11 @@ class DenseFieldTransform(TransformBase):
 
     def to_x5(self, metadata=None):
         """Return an :class:`~nitransforms.io.x5.X5Transform` representation."""
-        from ._version import __version__
-        from .io.x5 import X5Domain, X5Transform
-
         metadata = {"WrittenBy": f"NiTransforms {__version__}"} | (metadata or {})
 
         domain = None
         if (reference := self.reference) is not None:
-            domain = X5Domain(
+            domain = io.x5.X5Domain(
                 grid=True,
                 size=getattr(reference, "shape", (0, 0, 0)),
                 mapping=reference.affine,
@@ -246,7 +250,7 @@ class DenseFieldTransform(TransformBase):
 
         kinds = tuple("space" for _ in range(self.ndim)) + ("vector",)
 
-        return X5Transform(
+        return io.x5.X5Transform(
             type="nonlinear",
             subtype="densefield",
             representation="displacements",
@@ -270,6 +274,7 @@ class DenseFieldTransform(TransformBase):
 
         if fmt == "X5":
             from .io.x5 import from_filename as load_x5
+
             x5_xfm = load_x5(filename)[0]
             Domain = namedtuple("Domain", "affine shape")
             reference = Domain(x5_xfm.domain.mapping, x5_xfm.domain.size)
@@ -333,14 +338,11 @@ class BSplineFieldTransform(TransformBase):
 
     def to_x5(self, metadata=None):
         """Return an :class:`~nitransforms.io.x5.X5Transform` representation."""
-        from ._version import __version__
-        from .io.x5 import X5Transform, X5Domain
-
         metadata = {"WrittenBy": f"NiTransforms {__version__}"} | (metadata or {})
 
         domain = None
         if (reference := self.reference) is not None:
-            domain = X5Domain(
+            domain = io.x5.X5Domain(
                 grid=True,
                 size=getattr(reference, "shape", (0, 0, 0)),
                 mapping=reference.affine,
@@ -354,7 +356,7 @@ class BSplineFieldTransform(TransformBase):
 
         kinds = tuple("space" for _ in range(self.ndim)) + ("vector",)
 
-        return X5Transform(
+        return io.x5.X5Transform(
             type="nonlinear",
             subtype="bspline",
             representation="coefficients",

--- a/nitransforms/tests/test_nonlinear.py
+++ b/nitransforms/tests/test_nonlinear.py
@@ -14,6 +14,7 @@ from nitransforms.nonlinear import (
     BSplineFieldTransform,
     DenseFieldTransform,
 )
+from nitransforms import io
 from ..io.itk import ITKDisplacementsField
 
 
@@ -119,3 +120,47 @@ def test_bspline(tmp_path, testdata_path):
         ).mean()
         < 0.2
     )
+
+
+def test_densefield_x5_roundtrip(tmp_path):
+    """Ensure dense field transforms roundtrip via X5."""
+    ref = nb.Nifti1Image(np.zeros((2, 2, 2), dtype="uint8"), np.eye(4))
+    disp = nb.Nifti1Image(np.random.rand(2, 2, 2, 3).astype("float32"), np.eye(4))
+
+    xfm = DenseFieldTransform(disp, reference=ref)
+
+    node = xfm.to_x5(metadata={"GeneratedBy": "pytest"})
+    assert node.type == "nonlinear"
+    assert node.subtype == "densefield"
+    assert node.representation == "displacements"
+    assert node.domain.size == ref.shape
+    assert node.metadata["GeneratedBy"] == "pytest"
+
+    fname = tmp_path / "test.x5"
+    io.x5.to_filename(fname, [node])
+
+    xfm2 = DenseFieldTransform.from_filename(fname, fmt="X5")
+    diff = xfm2._deltas - xfm._deltas
+    coords = xfm.reference.ndcoords.T.reshape(xfm._deltas.shape)
+    assert np.allclose(diff, coords)
+    assert xfm2.reference.shape == ref.shape
+    assert np.allclose(xfm2.reference.affine, ref.affine)
+
+
+def test_bspline_to_x5(tmp_path):
+    """Check BSpline transforms export to X5."""
+    coeff = nb.Nifti1Image(np.zeros((2, 2, 2, 3), dtype="float32"), np.eye(4))
+    ref = nb.Nifti1Image(np.zeros((2, 2, 2), dtype="uint8"), np.eye(4))
+
+    xfm = BSplineFieldTransform(coeff, reference=ref)
+    node = xfm.to_x5(metadata={"tool": "pytest"})
+    assert node.type == "nonlinear"
+    assert node.subtype == "bspline"
+    assert node.representation == "coefficients"
+    assert node.metadata["tool"] == "pytest"
+
+    fname = tmp_path / "bspline.x5"
+    io.x5.to_filename(fname, [node])
+    node2 = io.x5.from_filename(fname)[0]
+    assert np.allclose(node2.transform, node.transform)
+    assert node2.metadata["tool"] == "pytest"


### PR DESCRIPTION
Extends support of nonlinear transforms to export/import X5 representation. New unit tests exercise the new I/O.

Cross-references: #241.