### PR TITLE
Enable X5 chains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ CHANGES
 -------
 * FIX: Broken 4D resampling by @oesteban in https://github.com/nipy/nitransforms/pull/247
 * ENH: Loading of X5 (linear) transforms by @oesteban in https://github.com/nipy/nitransforms/pull/243
+* ENH: Add X5 support to transform chains by @oesteban
 * ENH: Implement X5 representation and output to filesystem by @oesteban in https://github.com/nipy/nitransforms/pull/241
 * DOC: Fix references to ``os.PathLike`` by @oesteban in https://github.com/nipy/nitransforms/pull/242
 * MNT: Increase coverage by testing edge cases and adding docstrings by @oesteban in https://github.com/nipy/nitransforms/pull/248

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -193,6 +193,8 @@ class TransformChain(TransformBase):
     def from_filename(cls, filename, fmt="X5", reference=None, moving=None):
         """Load a transform file."""
         from .io import itk
+        from .io.x5 import from_filename as load_x5
+        from . import linear as nitl
 
         retval = []
         if str(filename).endswith(".h5"):
@@ -203,6 +205,24 @@ class TransformChain(TransformBase):
                     retval.insert(0, Affine(xfmobj.to_ras(), reference=reference))
                 else:
                     retval.insert(0, DenseFieldTransform(xfmobj))
+
+            return TransformChain(retval)
+
+        if fmt.upper() == "X5" or str(filename).endswith(".x5"):
+            for i, x5_xfm in enumerate(load_x5(filename)):
+                if x5_xfm.type != "linear":
+                    raise NotImplementedError(
+                        "Only linear X5 transforms are currently supported"
+                    )
+
+                xfm = nitl.Affine.from_filename(
+                    filename,
+                    fmt="X5",
+                    reference=reference,
+                    moving=moving,
+                    x5_position=i,
+                )
+                retval.append(xfm)
 
             return TransformChain(retval)
 

--- a/nitransforms/tests/test_x5.py
+++ b/nitransforms/tests/test_x5.py
@@ -3,6 +3,8 @@ import pytest
 from h5py import File as H5File
 
 from ..io.x5 import X5Transform, X5Domain, to_filename, from_filename
+from nitransforms import linear as nitl
+from nitransforms import manip as nitm
 
 
 def test_x5_transform_defaults():
@@ -75,3 +77,15 @@ def test_from_filename_invalid(tmp_path):
 
     with pytest.raises(TypeError):
         from_filename(fname)
+
+
+def test_transformchain_from_x5(tmp_path):
+    aff1 = nitl.Affine.from_matvec(vec=(1, 2, 3))
+    aff2 = nitl.Affine.from_matvec(vec=(-1, -2, -3))
+    fname = tmp_path / "chain.x5"
+    to_filename(fname, [aff1.to_x5(), aff2.to_x5()])
+
+    chain = nitm.TransformChain.from_filename(fname, fmt="X5")
+    assert len(chain.transforms) == 2
+    assert chain.transforms[0] == aff1
+    assert chain.transforms[1] == aff2


### PR DESCRIPTION
## Summary
- allow loading `.x5` files into `TransformChain`
- test TransformChain X5 loading
- document support in changelog

## Testing
- `pytest -q nitransforms/tests/test_x5.py::test_transformchain_from_x5`


------
https://chatgpt.com/codex/tasks/task_e_687bb72cab988330a5e9113198dce53e