### PR TITLE
ENH: X5 read/write support of ``TransformChain``

### DIFF
--- a/nitransforms/io/x5.py
+++ b/nitransforms/io/x5.py
@@ -26,7 +26,7 @@ import h5py
 import numpy as np
 
 
-@dataclass
+@dataclass(eq=True)
 class X5Domain:
     """Domain information of a transform representing reference/moving spaces."""
 

--- a/nitransforms/io/x5.py
+++ b/nitransforms/io/x5.py
@@ -105,35 +105,7 @@ def to_filename(fname: str | Path, x5_list: List[X5Transform]):
         tg = out_file.create_group("TransformGroup")
         for i, node in enumerate(x5_list):
             g = tg.create_group(str(i))
-            g.attrs["Type"] = node.type
-            g.attrs["ArrayLength"] = node.array_length
-            if node.subtype is not None:
-                g.attrs["SubType"] = node.subtype
-            if node.representation is not None:
-                g.attrs["Representation"] = node.representation
-            if node.metadata is not None:
-                g.attrs["Metadata"] = json.dumps(node.metadata)
-            g.create_dataset("Transform", data=node.transform)
-            g.create_dataset(
-                "DimensionKinds",
-                data=np.asarray(node.dimension_kinds, dtype="S"),
-            )
-            if node.domain is not None:
-                dgrp = g.create_group("Domain")
-                dgrp.create_dataset("Grid", data=np.uint8(1 if node.domain.grid else 0))
-                dgrp.create_dataset("Size", data=np.asarray(node.domain.size))
-                dgrp.create_dataset("Mapping", data=node.domain.mapping)
-                if node.domain.coordinates is not None:
-                    dgrp.attrs["Coordinates"] = node.domain.coordinates
-
-            if node.inverse is not None:
-                g.create_dataset("Inverse", data=node.inverse)
-            if node.jacobian is not None:
-                g.create_dataset("Jacobian", data=node.jacobian)
-            if node.additional_parameters is not None:
-                g.create_dataset(
-                    "AdditionalParameters", data=node.additional_parameters
-                )
+            _write_x5_group(g, node)
     return fname
 
 
@@ -188,3 +160,30 @@ def _read_x5_group(node) -> X5Transform:
         )
 
     return x5
+
+
+def _write_x5_group(g, node: X5Transform):
+    """Write one :class:`X5Transform` element into an opened HDF5 group."""
+    g.attrs["Type"] = node.type
+    g.attrs["ArrayLength"] = node.array_length
+    if node.subtype is not None:
+        g.attrs["SubType"] = node.subtype
+    if node.representation is not None:
+        g.attrs["Representation"] = node.representation
+    if node.metadata is not None:
+        g.attrs["Metadata"] = json.dumps(node.metadata)
+    g.create_dataset("Transform", data=node.transform)
+    g.create_dataset("DimensionKinds", data=np.asarray(node.dimension_kinds, dtype="S"))
+    if node.domain is not None:
+        dgrp = g.create_group("Domain")
+        dgrp.create_dataset("Grid", data=np.uint8(1 if node.domain.grid else 0))
+        dgrp.create_dataset("Size", data=np.asarray(node.domain.size))
+        dgrp.create_dataset("Mapping", data=node.domain.mapping)
+        if node.domain.coordinates is not None:
+            dgrp.attrs["Coordinates"] = node.domain.coordinates
+    if node.inverse is not None:
+        g.create_dataset("Inverse", data=node.inverse)
+    if node.jacobian is not None:
+        g.create_dataset("Jacobian", data=node.jacobian)
+    if node.additional_parameters is not None:
+        g.create_dataset("AdditionalParameters", data=node.additional_parameters)

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -186,22 +186,9 @@ should be (0, 0, 0, 1), got %s."""
         """Create an affine from a transform file."""
 
         if fmt and fmt.upper() == "X5":
-            x5_xfm = load_x5(filename)[x5_position]
-            Transform = cls if x5_xfm.array_length == 1 else LinearTransformsMapping
-            if (
-                x5_xfm.domain
-                and not x5_xfm.domain.grid
-                and len(x5_xfm.domain.size) == 3
-            ):  # pragma: no cover
-                raise NotImplementedError(
-                    "Only 3D regularly gridded domains are supported"
-                )
-            elif x5_xfm.domain:
-                # Override reference
-                Domain = namedtuple("Domain", "affine shape")
-                reference = Domain(x5_xfm.domain.mapping, x5_xfm.domain.size)
-
-            return Transform(x5_xfm.transform, reference=reference)
+            return from_x5(
+                load_x5(filename), reference=reference, x5_position=x5_position
+            )
 
         fmtlist = [fmt] if fmt is not None else ("itk", "lta", "afni", "fsl")
 
@@ -458,3 +445,20 @@ def load(filename, fmt=None, reference=None, moving=None):
         xfm = xfm[0]
 
     return xfm
+
+
+def from_x5(x5_list, reference=None, x5_position=0):
+    """Create an affine from a list of :class:`~nitransforms.io.x5.X5Transform` objects."""
+
+    x5_xfm = x5_list[x5_position]
+    Transform = Affine if x5_xfm.array_length == 1 else LinearTransformsMapping
+    if (
+        x5_xfm.domain and not x5_xfm.domain.grid and len(x5_xfm.domain.size) == 3
+    ):  # pragma: no cover
+        raise NotImplementedError("Only 3D regularly gridded domains are supported")
+    elif x5_xfm.domain:
+        # Override reference
+        Domain = namedtuple("Domain", "affine shape")
+        reference = Domain(x5_xfm.domain.mapping, x5_xfm.domain.size)
+
+    return Transform(x5_xfm.transform, reference=reference)

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -122,6 +122,9 @@ should be (0, 0, 0, 1), got %s."""
         True
 
         """
+        if not hasattr(other, "matrix"):
+            return False
+
         _eq = np.allclose(self.matrix, other.matrix, rtol=EQUALITY_TOL)
         if _eq and self._reference != other._reference:
             warnings.warn("Affines are equal, but references do not match.")

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -120,6 +120,10 @@ should be (0, 0, 0, 1), got %s."""
         >>> xfm2 = Affine(xfm1.matrix)
         >>> xfm1 == xfm2
         True
+        >>> xfm1 == Affine()
+        False
+        >>> xfm1 == TransformBase()
+        False
 
         """
         if not hasattr(other, "matrix"):

--- a/nitransforms/manip.py
+++ b/nitransforms/manip.py
@@ -19,13 +19,13 @@ from nitransforms.base import (
 )
 from nitransforms.io import itk, x5 as x5io
 from nitransforms.io.x5 import from_filename as load_x5
-from nitransforms.linear import (
+from nitransforms.linear import (  # noqa: F401
     Affine,
-    from_x5 as linear_from_x5,  # noqa: F401
+    from_x5 as linear_from_x5,
 )
-from nitransforms.nonlinear import (
+from nitransforms.nonlinear import (  # noqa: F401
     DenseFieldTransform,
-    from_x5 as nonlinear_from_x5,  # noqa: F401
+    from_x5 as nonlinear_from_x5,
 )
 
 
@@ -224,8 +224,9 @@ class TransformChain(TransformBase):
                     raise TransformError("X5 file contains no TransformChain")
 
                 chain_path = chain_grp[str(x5_chain)][()]
-                if isinstance(chain_path, bytes):
-                    chain_path = chain_path.decode()
+                chain_path = (
+                    chain_path.decode() if isinstance(chain_path, bytes) else chain_path
+                )
 
             return TransformChain([xfm_list[int(idx)] for idx in chain_path.split("/")])
 

--- a/nitransforms/nonlinear.py
+++ b/nitransforms/nonlinear.py
@@ -247,6 +247,9 @@ class DenseFieldTransform(TransformBase):
         True
 
         """
+        if not hasattr(other, "_field"):
+            return False
+
         _eq = np.allclose(self._field, other._field)
         if _eq and self._reference != other._reference:
             warnings.warn("Fields are equal, but references do not match.")
@@ -321,6 +324,28 @@ class BSplineFieldTransform(TransformBase):
                     "Number of components of the coefficients does "
                     "not match the number of dimensions"
                 )
+
+    def __eq__(self, other):
+        """
+        Overload equals operator.
+
+        Examples
+        --------
+        >>> xfm1 = BSplineFieldTransform(test_dir / "someones_bspline_coefficients.nii.gz")
+        >>> xfm2 = BSplineFieldTransform(test_dir / "someones_bspline_coefficients.nii.gz")
+        >>> xfm1 == xfm2
+        True
+
+        """
+        if not hasattr(other, "_coeffs"):
+            return False
+
+        _eq = np.allclose(self._coeffs, other._coeffs)
+        _eq = _eq and self._order == other._order
+
+        if _eq and self._reference != other._reference:
+            warnings.warn("Coefficients are equal, but references do not match.")
+        return _eq
 
     @property
     def ndim(self):

--- a/nitransforms/tests/test_manip.py
+++ b/nitransforms/tests/test_manip.py
@@ -59,11 +59,14 @@ def test_transformchain_x5_roundtrip(tmp_path):
 
     fname = tmp_path / "chain.x5"
     chain.to_filename(fname)
+
+    with h5py.File(fname) as f:
+        assert len(f["TransformGroup"]) == 2
+
     chain.to_filename(fname)  # append again, should not duplicate transforms
 
     with h5py.File(fname) as f:
         assert len(f["TransformGroup"]) == 2
-        assert len(f["TransformChain"]) == 2
 
     loaded0 = TransformChain.from_filename(fname, fmt="X5", x5_chain=0)
     loaded1 = TransformChain.from_filename(fname, fmt="X5", x5_chain=1)

--- a/nitransforms/tests/test_resampling.py
+++ b/nitransforms/tests/test_resampling.py
@@ -284,7 +284,7 @@ def test_apply_transformchain(tmp_path, testdata_path):
         / "ds-005_sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5"
     )
 
-    xfm = nitm.load(xfm_fname)
+    xfm = nitm.load(xfm_fname, fmt="itk")
 
     assert len(xfm) == 2
 


### PR DESCRIPTION
## Summary
- Facilitates the reading of X5 transforms by adding a ``from_x5()`` function in the ``nitransforms.linear`` and ``nitransforms.nonlinear`` modules.
- Reading and writing of transform chains in X5 files, ensuring X5 files do not contain duplicated transforms.
- Ensures all individual transforms implement ``__eq__()``.

100% coverage of the patch.