### PR TITLE
Fix SimpleITK install on minimal tox run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ test = [
     "pytest-env",
     "pytest-xdist >= 2.5",
     "coverage[toml] >= 5.2.1",
+    "SimpleITK ~= 2.5",
+    "scikit-build",
     "nitransforms[niftiext]",
 ]
 # Aliases


### PR DESCRIPTION
## Summary
- pin SimpleITK to the 2.5 series so uv resolves a wheel instead of an old source build

## Testing
- `tox -e py312-latest --notest -v`


------
https://chatgpt.com/codex/tasks/task_e_68811c802db08330bc1b15827676ff37