### PR TITLE
ENH: Add transform analysis utils

### DIFF
--- a/docs/_api/analysis.rst
+++ b/docs/_api/analysis.rst
@@ -1,0 +1,6 @@
+========
+Analysis
+========
+
+.. automodule:: nitransforms.analysis.utils
+    :members:

--- a/docs/_api/resampling.rst
+++ b/docs/_api/resampling.rst
@@ -1,0 +1,6 @@
+==========
+Resampling
+==========
+
+.. automodule:: nitransforms.resampling
+    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,11 +5,13 @@ Information on specific functions, classes, and methods for developers.
 .. toctree::
    :maxdepth: 1
 
+   _api/analysis
    _api/base
+   _api/interp
    _api/io
    _api/linear
    _api/manip
    _api/nonlinear
-   _api/surface
-   _api/interp
    _api/patched
+   _api/resampling
+   _api/surface

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,14 +39,13 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
+    "matplotlib.sphinxext.plot_directive",
 ]
 
 autodoc_mock_imports = [
-    "matplotlib",
     "nilearn",
     "nipy",
     "nitime",
-    "numpy",
     "pandas",
     "seaborn",
     "skimage",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 ipython
+matplotlib
 nbsphinx
 packaging
 pydot>=1.2.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 ipython
 matplotlib
 nbsphinx
+numpy
 packaging
 pydot>=1.2.3
 pydotplus

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -24,6 +24,7 @@ from typing import Tuple
 
 import nibabel as nb
 import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 from nitransforms.base import TransformBase
 from nitransforms.linear import Affine
@@ -166,6 +167,33 @@ def displacements_within_mask(
     return np.linalg.norm(diffs, axis=-1)
 
 
+def euler_from_matrix(affine: np.ndarray, degrees: bool = True) -> np.ndarray:
+    """Extract XYZ Euler angles from affine or rotation matrices using SciPy.
+
+    Parameters
+    ----------
+    affine : np.ndarray
+        Array with shape (..., 4, 4) or (..., 3, 3).
+    degrees : bool, optional
+        If True, return degrees; otherwise radians.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (..., 3), Euler angles in 'xyz' convention.
+    """
+    affine = np.asarray(affine, dtype=float)
+    if affine.shape[-2:] not in ((3, 3), (4, 4)):
+        raise ValueError("affine must end with shape (3, 3) or (4, 4).")
+
+    mats = affine[..., :3, :3]
+    batch_shape = mats.shape[:-2]
+    mats_2d = mats.reshape(-1, 3, 3)
+
+    angles = R.from_matrix(mats_2d).as_euler("xyz", degrees=degrees)
+    return angles.reshape(*batch_shape, 3)
+
+
 def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Extract translation (mm) and rotation (degrees) parameters from an affine matrix.
 
@@ -181,12 +209,8 @@ def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarra
     """
 
     translation = affine[:3, 3]
-    rotation_rad = np.arctan2(
-        [affine[2, 1], affine[0, 2], affine[1, 0]],
-        [affine[2, 2], affine[0, 0], affine[1, 1]],
-    )
-    rotation_deg = np.rad2deg(rotation_rad)
-    return *translation, *rotation_deg
+    rotation = euler_from_matrix(affine, degrees=True)
+    return *translation, *rotation
 
 
 def sample_unit_sphere(n_points: int = 8) -> np.ndarray:

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -62,9 +62,14 @@ def compute_fd_from_motion(
     Returns
     -------
     :obj:`~numpy.ndarray`
-        The framewise displacement (FD) asat each timepoint as the L1 norm of
+        The framewise displacement (FD) at each timepoint as the L1 norm of
         frame-to-frame displacement across translations and rotation-derived
         displacements.
+
+    Raises
+    ------
+    exc:`ValueError`
+        If ``motion_parameters`` is not a 2D array with shape ``(T, 6)``.
     """
 
     # Columns expected: [tx, ty, tz, rx, ry, rz] where rotations are in degrees
@@ -123,6 +128,10 @@ def compute_fd_from_transform(
     :obj:`float`
         The average framewise displacement (FD) for the test transformation.
 
+    Raises
+    ------
+    exc:`ValueError`
+        If ``n_vertices < 1``.
     """
     if n_vertices < 1:
         raise ValueError("n_vertices must be >= 1")
@@ -197,15 +206,20 @@ def euler_from_matrix(affine: np.ndarray, degrees: bool = True) -> np.ndarray:
 
     Parameters
     ----------
-    affine : np.ndarray
+    affine : :obj:`~numpy.ndarray`
         Array with shape (..., 4, 4) or (..., 3, 3).
-    degrees : bool, optional
+    degrees : :obj:`bool`, optional
         If True, return degrees; otherwise radians.
 
     Returns
     -------
-    np.ndarray
+   :obj:`~numpy.ndarray`
         Array of shape (..., 3), Euler angles in 'xyz' convention.
+
+    Raises
+    ------
+    :exc:`ValueError`
+        If ``affine`` does not end with shape ``(3, 3)`` or ``(4, 4)``.
     """
     affine = np.asarray(affine, dtype=float)
     if affine.shape[-2:] not in ((3, 3), (4, 4)):
@@ -254,13 +268,20 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
     Parameters
     ----------
-    n_points : int
+    n_points : obj:`int`
         Number of points on the sphere.
 
     Returns
     -------
-    numpy.ndarray
+    :obj:`~numpy.ndarray`
         An array of shape ``(n_points, 3)`` whose rows have unit norm.
+
+    Raises
+    ------
+    :exc:`TypeError`
+        If ``n_points`` is a boolean or not an integer type.
+    :exc:`ValueError`
+        If ``n_points < 1``.
 
     Examples
     --------

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -21,11 +21,16 @@ from scipy.stats import zscore
 from nitransforms.base import TransformBase
 
 
-RADIUS = 50.0
-"""Typical radius (in mm) of a sphere mimicking the size of a typical human brain."""
+DEFAULT_FD_RADIUS = 50.0
+"""
+Default radius (in mm) of a sphere where framewise displacements are calculated.
+The choice was proposed by
+`Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__, and it
+represents approximately the mean distance from the cerebral cortex to the center of the head.
+"""
 
 
-def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = RADIUS) -> np.ndarray:
+def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = DEFAULT_FD_RADIUS) -> np.ndarray:
     """Compute framewise displacement (FD) from motion parameters.
 
     Each row in the motion parameters represents one frame, and columns
@@ -158,7 +163,7 @@ def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarra
     return *translation, *rotation_deg
 
 
-def identify_spikes(fd: np.ndarray, threshold: float = 2.0) -> Tuple[np.ndarray, np.ndarray]:
+def identify_spikes(fd: np.ndarray, z_threshold: float = 2.0) -> Tuple[np.ndarray, np.ndarray]:
     """Identify motion spikes in framewise displacement data.
 
     Identifies high-motion frames as timepoint exceeding a given threshold value
@@ -168,7 +173,7 @@ def identify_spikes(fd: np.ndarray, threshold: float = 2.0) -> Tuple[np.ndarray,
     ----------
     fd : :obj:`~numpy.ndarray`
         Framewise displacement data.
-    threshold : :obj:`float`, optional
+    z_threshold : :obj:`float`, optional
         Threshold value to determine motion spikes.
 
     Returns
@@ -182,7 +187,7 @@ def identify_spikes(fd: np.ndarray, threshold: float = 2.0) -> Tuple[np.ndarray,
     # Normalize (z-score)
     fd_norm = zscore(fd)
 
-    mask = fd_norm > threshold
+    mask = fd_norm > z_threshold
     indices = np.where(mask)[0]
 
     return indices, mask

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -66,7 +66,18 @@ AFFINE_SEQ_SHAPE_ERROR = "Affine input must have shape (4, 4) or (T, 4, 4)."
 
 @dataclass(frozen=True)
 class MotionParameters:
-    """Representation for translation and rotation motion parameters."""
+    """Representation for translation and rotation motion parameters.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> params = MotionParameters(
+    ...     translations=np.zeros((3, 3)),
+    ...     rotations=np.zeros((3, 3))
+    ... )
+    >>> params.translations.shape
+    (3, 3)
+    """
 
     translations: np.ndarray
     """Translational motion parameters with shape ``(T, 3)`` in mm."""
@@ -116,6 +127,22 @@ def extract_motion_parameters(
     :exc:`ValueError`
         If ``motion_parameters`` does not have shape ``(T, 6)`` or if ``fmt``
         is unrecognized.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> raw_params = np.zeros((10, 6))
+    >>> params = extract_motion_parameters(raw_params, fmt=MOTION_FORMAT_FSL)
+    >>> params.translations.shape
+    (10, 3)
+    >>> params.rotations.shape
+    (10, 3)
+
+    >>> # Using AFNI format (rotations in degrees are converted to radians)
+    >>> afni_params = np.array([[1.0, 2.0, 3.0, 180.0, 0.0, 0.0]])
+    >>> params_afni = extract_motion_parameters(afni_params, fmt=MOTION_FORMAT_AFNI)
+    >>> np.allclose(params_afni.rotations[0, 0], np.pi)
+    True
     """
     arr = np.asarray(motion_parameters, dtype=float)
     if arr.ndim != 2 or arr.shape[1] != 6:
@@ -154,6 +181,21 @@ def affine_to_motion_params(
     -------
     :class:`~nitransforms.analysis.utils.MotionParameters`
         Structured translations and rotations.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> # Convert a single 4x4 affine matrix
+    >>> mat = np.eye(4)
+    >>> params = affine_to_motion_params(mat)
+    >>> params.translations.shape
+    (1, 3)
+
+    >>> # Convert a batch of 3 affine matrices (shape: T, 4, 4)
+    >>> batch_mat = np.tile(np.eye(4), (3, 1, 1))
+    >>> params_batch = affine_to_motion_params(batch_mat)
+    >>> params_batch.translations.shape
+    (3, 3)
     """
     # Check LinearTransformsMapping before Affine
     if isinstance(affine, LinearTransformsMapping):
@@ -201,6 +243,18 @@ def motion_params_to_affine(motion_parameters: MotionParameters) -> LinearTransf
     -------
     :class:`~nitransforms.linear.LinearTransformsMapping`
         A mapping representing the resolved sequence of affine transforms.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> # Create a MotionParameters record for 3 frames
+    >>> params = MotionParameters(
+    ...     translations=np.zeros((3, 3)),
+    ...     rotations=np.zeros((3, 3))
+    ... )
+    >>> mapping = motion_params_to_affine(params)
+    >>> len(mapping)
+    3
     """
     if not isinstance(motion_parameters, MotionParameters):
         raise TypeError(MOTION_PARAMS_INST_ERROR_MSG)
@@ -249,6 +303,17 @@ def compute_fd_from_motion(
     ------
     exc:`TypeError`
         If ``motion_parameters`` is not a :class:`MotionParameters` instance.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> params = MotionParameters(
+    ...     translations=np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]),
+    ...     rotations=np.zeros((2, 3))
+    ... )
+    >>> fd = compute_fd_from_motion(params)
+    >>> fd.shape
+    (2,)
     """
     if not isinstance(motion_parameters, MotionParameters):
         raise TypeError(MOTION_PARAMS_INST_ERROR_MSG)
@@ -307,6 +372,17 @@ def compute_fd_from_transform(
     ------
     exc:`ValueError`
         If ``n_vertices < 1``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import nibabel as nb
+    >>> from nitransforms.linear import Affine
+    >>> img = nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4))
+    >>> xfm = Affine()
+    >>> fd = compute_fd_from_transform(img, xfm)
+    >>> isinstance(fd, float)
+    True
     """
     if n_vertices < 1:
         raise ValueError("n_vertices must be >= 1")
@@ -360,6 +436,16 @@ def displacements_within_mask(
     :obj:`~numpy.ndarray`
         An array of displacements (in mm) for each voxel within the mask.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import nibabel as nb
+    >>> from nitransforms.linear import Affine
+    >>> mask_img = nb.Nifti1Image(np.ones((3, 3, 3)), np.eye(4))
+    >>> xfm = Affine()
+    >>> disps = displacements_within_mask(mask_img, xfm)
+    >>> disps.shape
+    (27,)
     """
     # Mask data as boolean (True for voxels inside the mask)
     maskdata = np.asanyarray(mask_img.dataobj) > 0

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -93,7 +93,8 @@ def compute_fd_from_transform(
 
     This implementation varies with respect to the original formulation by [Power2012]_
     in that the FD is computed as the average across a number of vertices sampled over the
-    sphere.
+    sphere. See :func:`~nitransforms.analysis.utils.sample_unit_sphere` for details
+    about the vertex sampling method.
 
     Parameters
     ----------

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -62,8 +62,9 @@ def compute_fd_from_motion(
     Returns
     -------
     :obj:`~numpy.ndarray`
-        The framewise displacement (FD) as the sum of absolute differences
-        between consecutive frames.
+        The framewise displacement (FD) asat each timepoint as the L1 norm of
+        frame-to-frame displacement across translations and rotation-derived
+        displacements.
     """
 
     # Columns expected: [tx, ty, tz, rx, ry, rz] where rotations are in degrees

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -1,0 +1,188 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Utilities to aid in performing and evaluating image registration.
+
+This module provides functions to compute displacements of image coordinates
+under a transformation, useful for assessing the accuracy of image registration
+processes.
+
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Tuple
+
+import nibabel as nb
+import numpy as np
+from scipy.stats import zscore
+
+from nitransforms.base import TransformBase
+
+
+RADIUS = 50.0
+"""Typical radius (in mm) of a sphere mimicking the size of a typical human brain."""
+
+
+def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = RADIUS) -> np.ndarray:
+    """Compute framewise displacement (FD) from motion parameters.
+
+    Each row in the motion parameters represents one frame, and columns
+    represent each coordinate axis ``x``, `y``, and ``z``. Translation
+    parameters are followed by rotation parameters column-wise.
+
+    Parameters
+    ----------
+    motion_parameters : :obj:`~numpy.ndarray`
+        Motion parameters.
+    radius : :obj:`float`, optional
+        Radius (in mm) of a sphere mimicking the size of a typical human brain.
+
+    Returns
+    -------
+    :obj:`~numpy.ndarray`
+        The framewise displacement (FD) as the sum of absolute differences
+        between consecutive frames.
+    """
+
+    translations = motion_parameters[:, :3]
+    rotations_deg = motion_parameters[:, 3:]
+    rotations_rad = np.deg2rad(rotations_deg)
+
+    # Compute differences between consecutive frames
+    d_translations = np.vstack([np.zeros((1, 3)), np.diff(translations, axis=0)])
+    d_rotations = np.vstack([np.zeros((1, 3)), np.diff(rotations_rad, axis=0)])
+
+    # Convert rotations from radians to displacement on a sphere
+    rotation_displacement = d_rotations * radius
+
+    # Compute FD as sum of absolute differences
+    return np.sum(np.abs(d_translations) + np.abs(rotation_displacement), axis=1)
+
+
+def compute_fd_from_transform(
+    img: nb.spatialimages.SpatialImage,
+    test_xfm: TransformBase,
+    radius: float = RADIUS,
+) -> float:
+    """
+    Compute the framewise displacement (FD) for a given transformation.
+
+    Parameters
+    ----------
+    img : :obj:`~nibabel.spatialimages.SpatialImage`
+        The reference image. Used to extract the center coordinates.
+    test_xfm : :obj:`~nitransforms.base.TransformBase`
+        The transformation to test. Applied to coordinates around the image center.
+    radius : :obj:`float`, optional
+        The radius (in mm) of the spherical neighborhood around the center of the image.
+
+    Returns
+    -------
+    :obj:`float`
+        The average framewise displacement (FD) for the test transformation.
+
+    """
+    affine = img.affine
+    # Compute the center of the image in voxel space
+    center_ijk = 0.5 * (np.array(img.shape[:3]) - 1)
+    # Convert to world coordinates
+    center_xyz = nb.affines.apply_affine(affine, center_ijk)
+    # Generate coordinates of points at radius distance from center
+    fd_coords = np.array(list(product(*((radius, -radius),) * 3))) + center_xyz
+    # Compute the average displacement from the test transformation
+    return np.mean(np.linalg.norm(test_xfm.map(fd_coords) - fd_coords, axis=-1))
+
+
+def displacements_within_mask(
+    mask_img: nb.spatialimages.SpatialImage,
+    test_xfm: TransformBase,
+    reference_xfm: TransformBase | None = None,
+) -> np.ndarray:
+    """
+    Compute the distance between voxel coordinates mapped through two transforms.
+
+    Parameters
+    ----------
+    mask_img : :obj:`~nibabel.spatialimages.SpatialImage`
+        A mask image that defines the region of interest. Voxel coordinates
+        within the mask are transformed.
+    test_xfm : :obj:`~nitransforms.base.TransformBase`
+        The transformation to test. This transformation is applied to the
+        voxel coordinates.
+    reference_xfm : :obj:`~nitransforms.base.TransformBase`, optional
+        A reference transformation to compare with. If ``None``, the identity
+        transformation is assumed (no transformation).
+
+    Returns
+    -------
+    :obj:`~numpy.ndarray`
+        An array of displacements (in mm) for each voxel within the mask.
+
+    """
+    # Mask data as boolean (True for voxels inside the mask)
+    maskdata = np.asanyarray(mask_img.dataobj) > 0
+    # Convert voxel coordinates to world coordinates using affine transform
+    xyz = nb.affines.apply_affine(
+        mask_img.affine,
+        np.argwhere(maskdata),
+    )
+    # Apply the test transformation
+    targets = test_xfm.map(xyz)
+
+    # Compute the difference (displacement) between the test and reference transformations
+    diffs = targets - xyz if reference_xfm is None else targets - reference_xfm.map(xyz)
+    return np.linalg.norm(diffs, axis=-1)
+
+
+def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract translation (mm) and rotation (degrees) parameters from an affine matrix.
+
+    Parameters
+    ----------
+    affine : :obj:`~numpy.ndarray`
+        The affine transformation matrix.
+
+    Returns
+    -------
+    :obj:`tuple`
+        Extracted translation and rotation parameters.
+    """
+
+    translation = affine[:3, 3]
+    rotation_rad = np.arctan2(
+        [affine[2, 1], affine[0, 2], affine[1, 0]], [affine[2, 2], affine[0, 0], affine[1, 1]]
+    )
+    rotation_deg = np.rad2deg(rotation_rad)
+    return *translation, *rotation_deg
+
+
+def identify_spikes(fd: np.ndarray, threshold: float = 2.0) -> Tuple[np.ndarray, np.ndarray]:
+    """Identify motion spikes in framewise displacement data.
+
+    Identifies high-motion frames as timepoint exceeding a given threshold value
+    based on z-score normalized framewise displacement (FD) values.
+
+    Parameters
+    ----------
+    fd : :obj:`~numpy.ndarray`
+        Framewise displacement data.
+    threshold : :obj:`float`, optional
+        Threshold value to determine motion spikes.
+
+    Returns
+    -------
+    indices : :obj:`~numpy.ndarray`
+        Indices of identified motion spikes.
+    mask : :obj:`~numpy.ndarray`
+        Mask of identified motion spikes.
+    """
+
+    # Normalize (z-score)
+    fd_norm = zscore(fd)
+
+    mask = fd_norm > threshold
+    indices = np.where(mask)[0]
+
+    return indices, mask

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -73,7 +73,7 @@ def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = DEFAUL
 def compute_fd_from_transform(
     img: nb.spatialimages.SpatialImage,
     test_xfm: TransformBase,
-    radius: float = RADIUS,
+    radius: float = DEFAULT_FD_RADIUS,
 ) -> float:
     """
     Compute the framewise displacement (FD) for a given transformation.

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -268,7 +268,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
     Parameters
     ----------
-    n_points : obj:`int`
+    n_points : :obj:`int`
         Number of points on the sphere.
 
     Returns

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -19,15 +19,15 @@ from __future__ import annotations
 
 
 import math
+from dataclasses import dataclass
 from itertools import product
-from typing import Tuple
 
 import nibabel as nb
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from nitransforms.base import TransformBase
-from nitransforms.linear import Affine
+from nitransforms.linear import Affine, LinearTransformsMapping
 
 
 DEFAULT_FD_RADIUS = 50.0
@@ -37,9 +37,191 @@ The choice was proposed by [Power2012]_, and it represents approximately the mea
 distance from the cerebral cortex to the center of the head.
 """
 
+MOTION_FORMAT_AFNI = "afni"
+"""AFNI motion parameter format identifier."""
+MOTION_FORMAT_FSL = "fsl"
+"""FSL motion parameter format identifier."""
+
+TRANSLATIONS_ERROR_MSG = "'translations' must have shape (T, 3)."
+"""Translations shape error message"""
+ROTATIONS_SHAPE_ERROR_MSG = "'rotations' must have shape (R, 3)."
+"""Rotations shape error message."""
+MOTION_PARAMS_SHAPE_ERROR_MSG = "'motion_parameters' must have shape (T, 6)."
+"""Motion parameters shape error message"""
+MOTION_PARAMS_FMT_ERROR_MSG = (
+    "Unsupported motion parameter format: '{fmt}'. "
+    f"Supported formats are: '{MOTION_FORMAT_AFNI}', '{MOTION_FORMAT_FSL}'."
+)
+"""Unsupported motion parameter format error message."""
+MOTION_PARAMS_INST_ERROR_MSG = "'motion_parameters' must be a 'MotionParameters' instance."
+"""Motion parameters instance error message."""
+
+AFFINE_TYPE_ERROR_MSG = "Affine input must be a valid array, Affine, or LinearTransformsMapping."
+"""Affine input type error message."""
+AFFINE_SHAPE_ERROR = "Affine input must have shape (4, 4)."
+"""Affine shape error message."""
+AFFINE_SEQ_SHAPE_ERROR = "Affine input must have shape (4, 4) or (T, 4, 4)."
+"""Affine sequence error message."""
+
+
+@dataclass(frozen=True)
+class MotionParameters:
+    """Representation for translation and rotation motion parameters."""
+
+    translations: np.ndarray
+    """Translational motion parameters with shape ``(T, 3)`` in mm."""
+    rotations: np.ndarray
+    """Rotational motion parameters with shape ``(T, 3)``."""
+
+    def __post_init__(self):
+        object.__setattr__(self, "translations", np.asarray(self.translations, dtype=float))
+        object.__setattr__(self, "rotations", np.asarray(self.rotations, dtype=float))
+        if self.translations.ndim != 2 or self.translations.shape[1] != 3:
+            raise ValueError(TRANSLATIONS_ERROR_MSG)
+        if self.rotations.ndim != 2 or self.rotations.shape[1] != 3:
+            raise ValueError(ROTATIONS_SHAPE_ERROR_MSG)
+
+    def __iter__(self):
+        return iter((self.translations, self.rotations))
+
+
+def extract_motion_parameters(
+    motion_parameters: np.ndarray, fmt: str | None = None
+) -> MotionParameters:
+    """Extract translation and rotation parameters into :class:`MotionParameters`.
+
+    Parameters
+    ----------
+    motion_parameters : :obj:`~numpy.ndarray`
+        An ``(T, 6)`` array of motion parameters.
+    fmt : :obj:`str`, optional
+        Parameter format specification. Supported formats:
+
+        - `:data:`~nitransforms.analysis.utils.MOTION_FORMAT_AFNI`:
+          Assumes standard AFNI 6-column output where translations are
+          in the first three columns (in mm) and rotations are in the
+          subsequent three columns (converted from degrees to radians).
+        - :data:`~nitransforms.analysis.utils.MOTION_FORMAT_FSL` (or :obj:`None`):
+          Standard FSL-style 6-column format where translations are in
+          the first three columns and rotations are in the last three
+          columns.
+
+    Returns
+    -------
+    :class:`~nitransforms.analysis.utils.MotionParameters`
+        Structured translations and rotations.
+
+    Raises
+    ------
+    :exc:`ValueError`
+        If ``motion_parameters`` does not have shape ``(T, 6)`` or if ``fmt``
+        is unrecognized.
+    """
+    arr = np.asarray(motion_parameters, dtype=float)
+    if arr.ndim != 2 or arr.shape[1] != 6:
+        raise ValueError(MOTION_PARAMS_SHAPE_ERROR_MSG)
+
+    translations = arr[:, :3]
+    rotations = arr[:, 3:]
+
+    if fmt is not None:
+        fmt = fmt.lower()
+        if fmt == MOTION_FORMAT_AFNI:
+            # AFNI outputs rotations in degrees; convert to radians for
+            # internal consistency
+            rotations = np.deg2rad(rotations)
+        elif fmt == MOTION_FORMAT_FSL:
+            pass
+        else:
+            raise ValueError(MOTION_PARAMS_FMT_ERROR_MSG.format(fmt=fmt))
+
+    return MotionParameters(translations=translations, rotations=rotations)
+
+
+def affine_to_motion_params(
+    affine: Affine | LinearTransformsMapping | np.ndarray
+) -> MotionParameters:
+    """Convert an affine transformation or sequence of transformations into a :class:`MotionParameters`.
+
+    Parameters
+    ----------
+    affine : :obj:`~nitransforms.linear.Affine`, :obj:`~nitransforms.linear.LinearTransformsMapping`, or :obj:`~numpy.ndarray`
+        A single ``(4, 4)`` affine matrix, an :class:`~nitransforms.linear.Affine`
+        instance, a :class:`~nitransforms.linear.LinearTransformsMapping` sequence,
+        or a batch array of shape ``(T, 4, 4)``.
+
+    Returns
+    -------
+    :class:`~nitransforms.analysis.utils.MotionParameters`
+        Structured translations and rotations.
+    """
+    # Check LinearTransformsMapping before Affine
+    if isinstance(affine, LinearTransformsMapping):
+        matrices = affine.matrix
+    elif isinstance(affine, Affine):
+        matrices = affine.matrix[np.newaxis, :, :]
+    else:
+        try:
+            matrix = np.asarray(affine, dtype=float)
+        except (ValueError, TypeError) as e:
+            raise TypeError(AFFINE_TYPE_ERROR_MSG) from e
+
+        if matrix.ndim == 2:
+            if matrix.shape != (4, 4):
+                raise ValueError(AFFINE_SHAPE_ERROR)
+            matrices = matrix[np.newaxis, :, :]
+        elif matrix.ndim == 3:
+            if matrix.shape[1:] != (4, 4):
+                raise ValueError(AFFINE_SEQ_SHAPE_ERROR)
+            matrices = matrix
+        else:
+            raise ValueError(AFFINE_SEQ_SHAPE_ERROR)
+
+    T = matrices.shape[0]
+    translations = np.zeros((T, 3))
+    rotations = np.zeros((T, 3))
+
+    for i in range(T):
+        M = matrices[i]
+        translations[i] = M[:3, 3]
+        rotations[i] = nb.eulerangles.mat2euler(M[:3, :3])
+
+    return MotionParameters(translations=translations, rotations=rotations)
+
+
+def motion_params_to_affine(motion_parameters: MotionParameters) -> LinearTransformsMapping:
+    """Convert a :class:`MotionParameters` object into a :class:`LinearTransformsMapping`.
+
+    Parameters
+    ----------
+    motion_parameters : :class:`~nitransforms.analysis.utils.MotionParameters`
+        A :class:`MotionParameters` object holding translations and rotations.
+
+    Returns
+    -------
+    :class:`~nitransforms.linear.LinearTransformsMapping`
+        A mapping representing the resolved sequence of affine transforms.
+    """
+    if not isinstance(motion_parameters, MotionParameters):
+        raise TypeError(MOTION_PARAMS_INST_ERROR_MSG)
+
+    translations = motion_parameters.translations
+    rotations = motion_parameters.rotations
+    T = translations.shape[0]
+
+    transforms = []
+    for i in range(T):
+        R = nb.eulerangles.euler2mat(*rotations[i])
+        t = translations[i]
+        mat = nb.affines.from_matvec(R, t)
+        transforms.append(Affine(mat))
+
+    return LinearTransformsMapping(transforms)
+
 
 def compute_fd_from_motion(
-    motion_parameters: np.ndarray,
+    motion_parameters: MotionParameters,
+    *,
     radius: float = DEFAULT_FD_RADIUS,
 ) -> np.ndarray:
     """Compute framewise displacement (FD) from motion parameters.
@@ -48,14 +230,11 @@ def compute_fd_from_motion(
     and rotational motion, computed from the frame-to-frame differences along
     the three spatial axes [Power2012]_.
 
-    Each row in the motion parameters represents one frame, and columns
-    represent each coordinate axis ``x``, `y``, and ``z``. Translation
-    parameters are followed by rotation parameters column-wise.
-
     Parameters
     ----------
-    motion_parameters : :obj:`~numpy.ndarray`
-        Motion parameters.
+    motion_parameters : :obj:`MotionParameters`
+        Either a :class:`MotionParameters` instance, a `(T, 3)` array of translations,
+        or a legacy `(T, 6)` combined array.
     radius : :obj:`float`, optional
         Radius (in mm) of a sphere mimicking the size of a typical human brain.
 
@@ -68,19 +247,15 @@ def compute_fd_from_motion(
 
     Raises
     ------
-    exc:`ValueError`
-        If ``motion_parameters`` is not a 2D array with shape ``(T, 6)``.
+    exc:`TypeError`
+        If ``motion_parameters`` is not a :class:`MotionParameters` instance.
     """
+    if not isinstance(motion_parameters, MotionParameters):
+        raise TypeError(MOTION_PARAMS_INST_ERROR_MSG)
 
-    # Columns expected: [tx, ty, tz, rx, ry, rz] where rotations are in degrees
-    # FD is computed as Power-style L1 displacement sum across 6 motion components.
-    motion_parameters = np.asarray(motion_parameters, dtype=float)
-    if motion_parameters.ndim != 2 or motion_parameters.shape[1] != 6:
-        raise ValueError("motion_parameters must have shape (T, 6).")
+    translations = motion_parameters.translations
+    rotations = motion_parameters.rotations
 
-    translations = motion_parameters[:, :3]
-    rotations = np.deg2rad(motion_parameters[:, 3:])
-    
     displacements = np.hstack((
         np.diff(translations, axis=0, prepend=np.zeros((1, 3))),
         np.diff(rotations * radius, axis=0, prepend=np.zeros((1, 3)))
@@ -199,59 +374,6 @@ def displacements_within_mask(
     # Compute the difference (displacement) between the test and reference transformations
     diffs = targets - xyz if xfm_prev is None else targets - xfm_prev.map(xyz)
     return np.linalg.norm(diffs, axis=-1)
-
-
-def euler_from_matrix(affine: np.ndarray, degrees: bool = False) -> np.ndarray:
-    """Extract XYZ Euler angles from affine or rotation matrices using SciPy.
-
-    Parameters
-    ----------
-    affine : :obj:`~numpy.ndarray`
-        Array with shape (..., 4, 4) or (..., 3, 3).
-    degrees : :obj:`bool`, optional
-        If :obj:`True`, return degrees; otherwise radians.
-
-    Returns
-    -------
-   :obj:`~numpy.ndarray`
-        Array of shape (..., 3), Euler angles in 'xyz' convention.
-
-    Raises
-    ------
-    :exc:`ValueError`
-        If ``affine`` does not end with shape ``(3, 3)`` or ``(4, 4)``.
-    """
-    affine = np.asarray(affine, dtype=float)
-    if affine.shape[-2:] not in ((3, 3), (4, 4)):
-        raise ValueError("affine must end with shape (3, 3) or (4, 4).")
-
-    mats = affine[..., :3, :3]
-    batch_shape = mats.shape[:-2]
-    mats_2d = mats.reshape(-1, 3, 3)
-
-    angles = R.from_matrix(mats_2d).as_euler("xyz", degrees=degrees)
-    return angles.reshape(*batch_shape, 3)
-
-
-def extract_motion_parameters(affine: np.ndarray, degrees: bool = False) -> Tuple[np.ndarray, np.ndarray]:
-    """Extract translation (mm) and rotation parameters from an affine matrix.
-
-    Parameters
-    ----------
-    affine : :obj:`~numpy.ndarray`
-        The affine transformation matrix.
-    degrees : :obj:`bool`, optional
-        If :obj:`True`, return degrees; otherwise radians.
-
-    Returns
-    -------
-    :obj:`tuple`
-        Extracted translation and rotation parameters.
-    """
-
-    translation = affine[:3, 3]
-    rotation = euler_from_matrix(affine, degrees=degrees)
-    return *translation, *rotation
 
 
 def sample_unit_sphere(n_points: int = 8) -> np.ndarray:

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -307,6 +307,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
        import numpy as np
        import matplotlib.pyplot as plt
+       import mpl_toolkits.mplot3d
 
        from nitransforms.analysis.utils import sample_unit_sphere
 

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -93,6 +93,10 @@ def compute_fd_from_transform(
     sphere. See :func:`~nitransforms.analysis.utils.sample_unit_sphere` for details
     about the vertex sampling method.
 
+    For ``n_vertices == 1``, FD is computed from rigid-body parameter increments
+    (translation L1 + radius-scaled rotation L1) instead of averaging displacements
+    over sampled sphere points. See :func:`compute_fd_from_motion` for direct comparability.
+
     Parameters
     ----------
     img : :obj:`~nibabel.spatialimages.SpatialImage`
@@ -113,6 +117,20 @@ def compute_fd_from_transform(
         The average framewise displacement (FD) for the test transformation.
 
     """
+    if n_vertices < 1:
+        raise ValueError("n_vertices must be >= 1")
+
+    # For a single vertex, use rigid-body parameter increments (L1 translation + radius-scaled L1 rotation)
+    # instead of point sampling to avoid dependence on an arbitrary sphere vertex.
+    if n_vertices == 1:
+        # Relative transform from previous frame to current frame
+        rel = np.linalg.inv(xfm_prev.matrix) @ xfm.matrix
+
+        d_t = rel[:3, 3]
+        d_r = R.from_matrix(rel[:3, :3]).as_euler("xyz", degrees=False)
+
+        return float(np.linalg.norm(d_t, ord=1) + radius * np.linalg.norm(d_r, ord=1))
+
     xfm_prev = Affine() if xfm_prev is None else xfm_prev
 
     affine = img.affine

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -260,10 +260,10 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
     Notes
     -----
-    - There is no unique notion of "evenly distributed" for arbitrary ``N`` on a sphere.
-      This function uses:
-        * **Platonic solids** for certain small ``N`` (high symmetry; e.g. ``N=6`` gives
-          the ±axis points).
+    - There is no unique notion of "evenly distributed" for arbitrary :math:`N` on
+      a sphere. This function uses:
+        * **Platonic solids** for certain small :math:`N` (high symmetry; e.g.
+          :math:`N = 6` gives the :math:`\\pm` axis points).
         * A **Fibonacci / golden-angle spiral** otherwise (fast, simple, good coverage).
 
     Parameters
@@ -322,7 +322,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
            ax.set_box_aspect((1, 1, 1))
        fig.tight_layout()
 
-    For ``N=6``, return the :math:`\\pm`axis points (octahedron vertices):
+    For :math:`N = 6`, return the :math:`\\pm` axis points (octahedron vertices):
 
     >>> X = sample_unit_sphere(6)
     >>> # Each row has exactly one coordinate with magnitude 1, others 0
@@ -331,7 +331,8 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     >>> bool(np.all((np.abs(X) == 1.0).sum(axis=0) == 2))  # each axis appears twice (±)
     True
 
-    For ``N=4``, the tetrahedron has constant pairwise dot product -1/3 off-diagonal:
+    For :math:`N = 4`, the tetrahedron has constant pairwise dot product -1/3
+    off-diagonal:
 
     >>> X = sample_unit_sphere(4)
     >>> D = X @ X.T

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -308,6 +308,8 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
        import numpy as np
        import matplotlib.pyplot as plt
 
+       from nitransforms.analysis.utils import sample_unit_sphere
+
        values = (1, 2, 8, 10, 12, 20)
 
        fig = plt.figure(figsize=(10, 6))

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -66,12 +66,18 @@ def compute_fd_from_motion(
         between consecutive frames.
     """
 
+    # Columns expected: [tx, ty, tz, rx, ry, rz] where rotations are in degrees
+    # FD is computed as Power-style L1 displacement sum across 6 motion components.
+    motion_parameters = np.asarray(motion_parameters, dtype=float)
+    if motion_parameters.ndim != 2 or motion_parameters.shape[1] != 6:
+        raise ValueError("motion_parameters must have shape (T, 6).")
+
     translations = motion_parameters[:, :3]
     rotations = np.deg2rad(motion_parameters[:, 3:])
     
     displacements = np.hstack((
-        np.diff(translations, axis=0, prepend=0),
-        np.diff(rotations * radius, axis=0, prepend=0)
+        np.diff(translations, axis=0, prepend=np.zeros((1, 3))),
+        np.diff(rotations * radius, axis=0, prepend=np.zeros((1, 3)))
     ))
 
     # FD is the L1 norm (sum of absolute values)

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -24,7 +24,6 @@ from typing import Tuple
 
 import nibabel as nb
 import numpy as np
-from scipy.stats import zscore
 
 from nitransforms.base import TransformBase
 from nitransforms.linear import Affine
@@ -340,35 +339,3 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
     X = np.column_stack((r * np.cos(theta), r * np.sin(theta), z))
     return _normalize(X)
-
-
-def identify_spikes(
-    fd: np.ndarray, z_threshold: float = 2.0
-) -> Tuple[np.ndarray, np.ndarray]:
-    """Identify motion spikes in framewise displacement data.
-
-    Identifies high-motion frames as timepoint exceeding a given threshold value
-    based on z-score normalized framewise displacement (FD) values.
-
-    Parameters
-    ----------
-    fd : :obj:`~numpy.ndarray`
-        Framewise displacement data.
-    z_threshold : :obj:`float`, optional
-        Threshold value to determine motion spikes.
-
-    Returns
-    -------
-    indices : :obj:`~numpy.ndarray`
-        Indices of identified motion spikes.
-    mask : :obj:`~numpy.ndarray`
-        Mask of identified motion spikes.
-    """
-
-    # Normalize (z-score)
-    fd_norm = zscore(fd)
-
-    mask = fd_norm > z_threshold
-    indices = np.where(mask)[0]
-
-    return indices, mask

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -67,18 +67,15 @@ def compute_fd_from_motion(
     """
 
     translations = motion_parameters[:, :3]
-    rotations_deg = motion_parameters[:, 3:]
-    rotations_rad = np.deg2rad(rotations_deg)
+    rotations = np.deg2rad(motion_parameters[:, 3:])
+    
+    displacements = np.hstack((
+        np.diff(translations, axis=0, prepend=0),
+        np.diff(rotations * radius, axis=0, prepend=0)
+    ))
 
-    # Compute differences between consecutive frames
-    d_translations = np.vstack([np.zeros((1, 3)), np.diff(translations, axis=0)])
-    d_rotations = np.vstack([np.zeros((1, 3)), np.diff(rotations_rad, axis=0)])
-
-    # Convert rotations from radians to displacement on a sphere
-    rotation_displacement = d_rotations * radius
-
-    # Compute FD as sum of absolute differences
-    return np.sum(np.abs(d_translations) + np.abs(rotation_displacement), axis=1)
+    # FD is the L1 norm (sum of absolute values)
+    return np.linalg.norm(displacements, ord=1, axis=1)
 
 
 def compute_fd_from_transform(
@@ -126,7 +123,7 @@ def compute_fd_from_transform(
     # Generate coordinates of points at radius distance from center
     fd_coords = sample_unit_sphere(n_points=n_vertices) * radius + center_xyz
     # Compute the average displacement from the test transformation
-    return np.mean(np.linalg.norm(xfm.map(fd_coords) - xfm_prev.map(fd_coords), axis=-1))
+    return np.mean(np.linalg.norm(xfm.map(fd_coords) - xfm_prev.map(fd_coords), ord=1, axis=-1))
 
 
 def displacements_within_mask(

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -7,10 +7,18 @@ This module provides functions to compute displacements of image coordinates
 under a transformation, useful for assessing the accuracy of image registration
 processes.
 
+References
+----------
+.. [Power2012] Power, JD. et al. (2012). "Spurious but systematic correlations in functional
+   connectivity MRI networks arise from subject motion." NeuroImage, 59(3):2142-2154.
+   doi:`10.1016/j.neuroimage.2011.10.018 <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__.
+
 """
 
 from __future__ import annotations
 
+
+import math
 from itertools import product
 from typing import Tuple
 
@@ -24,9 +32,8 @@ from nitransforms.base import TransformBase
 DEFAULT_FD_RADIUS = 50.0
 """
 Default radius (in mm) of a sphere where framewise displacements are calculated.
-The choice was proposed by
-`Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__, and it
-represents approximately the mean distance from the cerebral cortex to the center of the head.
+The choice was proposed by [Power2012]_, and it represents approximately the mean
+distance from the cerebral cortex to the center of the head.
 """
 
 
@@ -38,8 +45,7 @@ def compute_fd_from_motion(
 
     The framewise displacement is the sum of the magnitudes of the translational
     and rotational motion, computed from the frame-to-frame differences along
-    the three spatial axes (
-    `Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__).
+    the three spatial axes [Power2012]_.
 
     Each row in the motion parameters represents one frame, and columns
     represent each coordinate axis ``x``, `y``, and ``z``. Translation
@@ -78,9 +84,14 @@ def compute_fd_from_transform(
     img: nb.spatialimages.SpatialImage,
     test_xfm: TransformBase,
     radius: float = DEFAULT_FD_RADIUS,
+    n_vertices: int = 8,
 ) -> float:
     """
     Compute the framewise displacement (FD) for a given transformation.
+
+    This implementation varies with respect to the original formulation by [Power2012]_
+    in that the FD is computed as the average across a number of vertices sample of the
+    sphere.
 
     Parameters
     ----------
@@ -90,6 +101,8 @@ def compute_fd_from_transform(
         The transformation to test. Applied to coordinates around the image center.
     radius : :obj:`float`, optional
         The radius (in mm) of the spherical neighborhood around the center of the image.
+    n_vertices : :obj:`int`, optional
+        The number of vertices to sample on the sphere.
 
     Returns
     -------
@@ -103,7 +116,7 @@ def compute_fd_from_transform(
     # Convert to world coordinates
     center_xyz = nb.affines.apply_affine(affine, center_ijk)
     # Generate coordinates of points at radius distance from center
-    fd_coords = np.array(list(product(*((radius, -radius),) * 3))) + center_xyz
+    fd_coords = sample_unit_sphere(n_points=n_vertices) * radius + center_xyz
     # Compute the average displacement from the test transformation
     return np.mean(np.linalg.norm(test_xfm.map(fd_coords) - fd_coords, axis=-1))
 
@@ -165,13 +178,159 @@ def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarra
 
     translation = affine[:3, 3]
     rotation_rad = np.arctan2(
-        [affine[2, 1], affine[0, 2], affine[1, 0]], [affine[2, 2], affine[0, 0], affine[1, 1]]
+        [affine[2, 1], affine[0, 2], affine[1, 0]],
+        [affine[2, 2], affine[0, 0], affine[1, 1]],
     )
     rotation_deg = np.rad2deg(rotation_rad)
     return *translation, *rotation_deg
 
 
-def identify_spikes(fd: np.ndarray, z_threshold: float = 2.0) -> Tuple[np.ndarray, np.ndarray]:
+def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
+    """Returns :math:`N` evenly distributed points on a unit-radius sphere.
+
+    This function returns a **deterministic**, **quasi-uniform** point set on the
+    surface of the unit sphere :math:`S^2 \\subset \\mathbb{R}^3`.
+
+    Notes
+    -----
+    - There is no unique notion of "evenly distributed" for arbitrary `N` on a sphere.
+      This function uses:
+        * **Platonic solids** for certain small `N` (high symmetry; e.g. `N=6` gives
+          the ±axis points).
+        * A **Fibonacci / golden-angle spiral** otherwise (fast, simple, good coverage).
+
+    Parameters
+    ----------
+    n_points : int
+        Number of points on the sphere.
+
+    Returns
+    -------
+    numpy.ndarray
+        An array of shape ``(n_points, 3)`` whose rows have unit norm.
+
+    Examples
+    --------
+    Basic shape + unit norm:
+
+    >>> import numpy as np
+    >>> X = sample_unit_sphere(10)
+    >>> X.shape
+    (10, 3)
+    >>> bool(np.allclose(np.linalg.norm(X, axis=1), 1.0))
+    True
+
+    Edge case:
+
+    >>> sample_unit_sphere(0)
+    Traceback (most recent call last):
+    ...
+    ValueError: n_points must be a positive integer
+
+    For N=6, return the ±axis points (octahedron vertices):
+
+    >>> X = sample_unit_sphere(6)
+    >>> # Each row has exactly one coordinate with magnitude 1, others 0
+    >>> bool(np.all((np.abs(X) == 1.0).sum(axis=1) == 1))
+    True
+    >>> bool(np.all((np.abs(X) == 1.0).sum(axis=0) == 2))  # each axis appears twice (±)
+    True
+
+    For N=4, the tetrahedron has constant pairwise dot product -1/3 off-diagonal:
+
+    >>> X = sample_unit_sphere(4)
+    >>> D = X @ X.T
+    >>> off = D[~np.eye(4, dtype=bool)]
+    >>> bool(np.allclose(off, -1/3))
+    True
+
+    For a quasi-uniform set, the second moment matrix is close to I/3, and the
+    minimum angular separation is non-trivial:
+
+    >>> X = sample_unit_sphere(200)
+    >>> M = (X.T @ X) / len(X)
+    >>> bool(np.allclose(M, np.eye(3) / 3, atol=1e-3))
+    True
+    >>> def min_angle_rad(Y):
+    ...     dots = np.clip(Y @ Y.T, -1.0, 1.0)
+    ...     np.fill_diagonal(dots, 1.0)
+    ...     ang = np.arccos(dots)
+    ...     np.fill_diagonal(ang, np.inf)
+    ...     return float(ang.min())
+    >>> min_angle_rad(X) > 0.18
+    True
+
+    """
+    if isinstance(n_points, (bool, np.bool_)) or not isinstance(
+        n_points, (int, np.integer)
+    ):
+        raise TypeError("n_points must be an integer")
+    if n_points < 1:
+        raise ValueError("n_points must be a positive integer")
+
+    def _normalize(X):
+        X = np.asarray(X, dtype=float)
+        X /= np.linalg.norm(X, axis=1, keepdims=True)
+        return X
+
+    # --- Highly symmetric small-N cases (Platonic solids / degeneracies) ---
+    if n_points == 1:
+        return np.array([[0.0, 0.0, 1.0]])
+    if n_points == 2:
+        return np.array([[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]])
+    if n_points == 4:  # tetrahedron (4 cube corners with even number of minus signs)
+        X = np.array(
+            [[1.0, 1.0, 1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, 1.0]]
+        )
+        return _normalize(X)
+    if n_points == 6:  # octahedron: ±axes
+        return np.vstack([np.eye(3), -np.eye(3)]).astype(float)
+    if n_points in (8, 20):  # hexahedron (cube) & base for dodecahedron
+        X = np.array(list(product([-1.0, 1.0], repeat=3)), dtype=float)
+        if n_points == 8:
+            return _normalize(X)
+
+        # Dodecahedron, add 12 vertices
+        extra = []
+        phi = (1.0 + math.sqrt(5.0)) / 2.0
+        invphi = 1.0 / phi
+        for a in (-1.0, 1.0):
+            for b in (-1.0, 1.0):
+                extra.extend(
+                    [
+                        [0.0, a * invphi, b * phi],
+                        [a * invphi, b * phi, 0.0],
+                        [a * phi, 0.0, b * invphi],
+                    ]
+                )
+        X = np.vstack([X, np.asarray(extra, dtype=float)])
+        return _normalize(X)
+
+    if n_points == 12:  # icosahedron
+        phi = (1.0 + math.sqrt(5.0)) / 2.0
+        X = []
+        for a in (-1.0, 1.0):
+            for b in (-1.0, 1.0):
+                X.append([0.0, a, b * phi])
+                X.append([a, b * phi, 0.0])
+                X.append([a * phi, 0.0, b])
+        return _normalize(X)
+
+    # --- General N: Fibonacci / golden-angle spiral (deterministic quasi-uniform) ---
+    i = np.arange(n_points, dtype=float)
+    golden_angle = math.pi * (3.0 - math.sqrt(5.0))
+
+    z = 1.0 - 2.0 * (i + 0.5) / n_points
+    r = np.sqrt(np.maximum(0.0, 1.0 - z * z))
+    theta = golden_angle * i
+
+    X = np.column_stack((r * np.cos(theta), r * np.sin(theta), z))
+    return _normalize(X)
+
+
+def identify_spikes(
+    fd: np.ndarray, z_threshold: float = 2.0
+) -> Tuple[np.ndarray, np.ndarray]:
     """Identify motion spikes in framewise displacement data.
 
     Identifies high-motion frames as timepoint exceeding a given threshold value

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -30,12 +30,16 @@ represents approximately the mean distance from the cerebral cortex to the cente
 """
 
 
-def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = DEFAULT_FD_RADIUS) -> np.ndarray:
+def compute_fd_from_motion(
+    motion_parameters: np.ndarray,
+    radius: float = DEFAULT_FD_RADIUS,
+) -> np.ndarray:
     """Compute framewise displacement (FD) from motion parameters.
 
     The framewise displacement is the sum of the magnitudes of the translational
     and rotational motion, computed from the frame-to-frame differences along
-    the three spatial axes (`Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__).
+    the three spatial axes (
+    `Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__).
 
     Each row in the motion parameters represents one frame, and columns
     represent each coordinate axis ``x``, `y``, and ``z``. Translation

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -27,6 +27,7 @@ import numpy as np
 from scipy.stats import zscore
 
 from nitransforms.base import TransformBase
+from nitransforms.linear import Affine
 
 
 DEFAULT_FD_RADIUS = 50.0
@@ -82,7 +83,8 @@ def compute_fd_from_motion(
 
 def compute_fd_from_transform(
     img: nb.spatialimages.SpatialImage,
-    test_xfm: TransformBase,
+    xfm: TransformBase,
+    xfm_prev: TransformBase | None = None,
     radius: float = DEFAULT_FD_RADIUS,
     n_vertices: int = 8,
 ) -> float:
@@ -97,8 +99,11 @@ def compute_fd_from_transform(
     ----------
     img : :obj:`~nibabel.spatialimages.SpatialImage`
         The reference image. Used to extract the center coordinates.
-    test_xfm : :obj:`~nitransforms.base.TransformBase`
+    xfm : :obj:`~nitransforms.base.TransformBase`
         The transformation to test. Applied to coordinates around the image center.
+    xfm_prev : :obj:`~nitransforms.base.TransformBase`, optional
+        A previous transformation to compare with. If ``None``, the identity
+        transformation is assumed (no transformation).
     radius : :obj:`float`, optional
         The radius (in mm) of the spherical neighborhood around the center of the image.
     n_vertices : :obj:`int`, optional
@@ -110,6 +115,8 @@ def compute_fd_from_transform(
         The average framewise displacement (FD) for the test transformation.
 
     """
+    xfm_prev = Affine() if xfm_prev is None else xfm_prev
+
     affine = img.affine
     # Compute the center of the image in voxel space
     center_ijk = 0.5 * (np.array(img.shape[:3]) - 1)
@@ -118,13 +125,13 @@ def compute_fd_from_transform(
     # Generate coordinates of points at radius distance from center
     fd_coords = sample_unit_sphere(n_points=n_vertices) * radius + center_xyz
     # Compute the average displacement from the test transformation
-    return np.mean(np.linalg.norm(test_xfm.map(fd_coords) - fd_coords, axis=-1))
+    return np.mean(np.linalg.norm(xfm.map(fd_coords) - xfm_prev.map(fd_coords), axis=-1))
 
 
 def displacements_within_mask(
     mask_img: nb.spatialimages.SpatialImage,
-    test_xfm: TransformBase,
-    reference_xfm: TransformBase | None = None,
+    xfm: TransformBase,
+    xfm_prev: TransformBase | None = None,
 ) -> np.ndarray:
     """
     Compute the distance between voxel coordinates mapped through two transforms.
@@ -134,11 +141,11 @@ def displacements_within_mask(
     mask_img : :obj:`~nibabel.spatialimages.SpatialImage`
         A mask image that defines the region of interest. Voxel coordinates
         within the mask are transformed.
-    test_xfm : :obj:`~nitransforms.base.TransformBase`
+    xfm : :obj:`~nitransforms.base.TransformBase`
         The transformation to test. This transformation is applied to the
         voxel coordinates.
-    reference_xfm : :obj:`~nitransforms.base.TransformBase`, optional
-        A reference transformation to compare with. If ``None``, the identity
+    xfm_prev : :obj:`~nitransforms.base.TransformBase`, optional
+        A previous (reference) transformation to compare with. If ``None``, the identity
         transformation is assumed (no transformation).
 
     Returns
@@ -155,10 +162,10 @@ def displacements_within_mask(
         np.argwhere(maskdata),
     )
     # Apply the test transformation
-    targets = test_xfm.map(xyz)
+    targets = xfm.map(xyz)
 
     # Compute the difference (displacement) between the test and reference transformations
-    diffs = targets - xyz if reference_xfm is None else targets - reference_xfm.map(xyz)
+    diffs = targets - xyz if xfm_prev is None else targets - xfm_prev.map(xyz)
     return np.linalg.norm(diffs, axis=-1)
 
 

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -267,8 +267,9 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     Basic shape + unit norm:
 
     >>> import numpy as np
-    >>> for n_points in (1, 2, 8, 10, 12, 20):
-    ...     X = sample_unit_sphere(n_points)
+    >>> values = (1, 2, 8, 10, 12, 20)
+    >>> for n_pts in values:
+    ...     X = sample_unit_sphere(n_pts)
     ...     X.shape, bool(np.allclose(np.linalg.norm(X, axis=1), 1.0))
     ((1, 3), True)
     ((2, 3), True)
@@ -277,7 +278,30 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     ((12, 3), True)
     ((20, 3), True)
 
-    For ``N=6``, return the ±axis points (octahedron vertices):
+    Visualization of sampled points for each case:
+
+    .. plot::
+       :context: close-figs
+       :include-source: true
+
+       import numpy as np
+       import matplotlib.pyplot as plt
+
+       values = (1, 2, 8, 10, 12, 20)
+
+       fig = plt.figure(figsize=(10, 6))
+       for i, n_pts in enumerate(values, start=1):
+           X = sample_unit_sphere(n_pts)
+           ax = fig.add_subplot(2, 3, i, projection="3d")
+           ax.scatter(X[:, 0], X[:, 1], X[:, 2], s=30)
+           ax.set_title(f"n={n_pts}")
+           ax.set_xlabel("x")
+           ax.set_ylabel("y")
+           ax.set_zlabel("z")
+           ax.set_box_aspect((1, 1, 1))
+       fig.tight_layout()
+
+    For ``N=6``, return the :math:`\\pm`axis points (octahedron vertices):
 
     >>> X = sample_unit_sphere(6)
     >>> # Each row has exactly one coordinate with magnitude 1, others 0

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -33,6 +33,10 @@ represents approximately the mean distance from the cerebral cortex to the cente
 def compute_fd_from_motion(motion_parameters: np.ndarray, radius: float = DEFAULT_FD_RADIUS) -> np.ndarray:
     """Compute framewise displacement (FD) from motion parameters.
 
+    The framewise displacement is the sum of the magnitudes of the translational
+    and rotational motion, computed from the frame-to-frame differences along
+    the three spatial axes (`Power et al. (2015) <https://doi.org/10.1016/j.neuroimage.2011.10.018>`__).
+
     Each row in the motion parameters represents one frame, and columns
     represent each coordinate axis ``x``, `y``, and ``z``. Translation
     parameters are followed by rotation parameters column-wise.

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -92,7 +92,7 @@ def compute_fd_from_transform(
     Compute the framewise displacement (FD) for a given transformation.
 
     This implementation varies with respect to the original formulation by [Power2012]_
-    in that the FD is computed as the average across a number of vertices sample of the
+    in that the FD is computed as the average across a number of vertices sampled over the
     sphere.
 
     Parameters
@@ -200,9 +200,9 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
 
     Notes
     -----
-    - There is no unique notion of "evenly distributed" for arbitrary `N` on a sphere.
+    - There is no unique notion of "evenly distributed" for arbitrary ``N`` on a sphere.
       This function uses:
-        * **Platonic solids** for certain small `N` (high symmetry; e.g. `N=6` gives
+        * **Platonic solids** for certain small ``N`` (high symmetry; e.g. ``N=6`` gives
           the ±axis points).
         * A **Fibonacci / golden-angle spiral** otherwise (fast, simple, good coverage).
 
@@ -231,7 +231,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     ((12, 3), True)
     ((20, 3), True)
 
-    For N=6, return the ±axis points (octahedron vertices):
+    For ``N=6``, return the ±axis points (octahedron vertices):
 
     >>> X = sample_unit_sphere(6)
     >>> # Each row has exactly one coordinate with magnitude 1, others 0
@@ -240,7 +240,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     >>> bool(np.all((np.abs(X) == 1.0).sum(axis=0) == 2))  # each axis appears twice (±)
     True
 
-    For N=4, the tetrahedron has constant pairwise dot product -1/3 off-diagonal:
+    For ``N=4``, the tetrahedron has constant pairwise dot product -1/3 off-diagonal:
 
     >>> X = sample_unit_sphere(4)
     >>> D = X @ X.T
@@ -248,7 +248,7 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     >>> bool(np.allclose(off, -1/3))
     True
 
-    For a quasi-uniform set, the second moment matrix is close to I/3, and the
+    For a quasi-uniform set, the second moment matrix is close to ``I/3``, and the
     minimum angular separation is non-trivial:
 
     >>> X = sample_unit_sphere(200)

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -214,18 +214,15 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     Basic shape + unit norm:
 
     >>> import numpy as np
-    >>> X = sample_unit_sphere(10)
-    >>> X.shape
-    (10, 3)
-    >>> bool(np.allclose(np.linalg.norm(X, axis=1), 1.0))
-    True
-
-    Edge case:
-
-    >>> sample_unit_sphere(0)
-    Traceback (most recent call last):
-    ...
-    ValueError: n_points must be a positive integer
+    >>> for n_points in (1, 2, 8, 10, 12, 20):
+    ...     X = sample_unit_sphere(n_points)
+    ...     X.shape, bool(np.allclose(np.linalg.norm(X, axis=1), 1.0))
+    ((1, 3), True)
+    ((2, 3), True)
+    ((8, 3), True)
+    ((10, 3), True)
+    ((12, 3), True)
+    ((20, 3), True)
 
     For N=6, return the ±axis points (octahedron vertices):
 
@@ -260,13 +257,25 @@ def sample_unit_sphere(n_points: int = 8) -> np.ndarray:
     >>> min_angle_rad(X) > 0.18
     True
 
+    Improper inputs:
+
+    >>> sample_unit_sphere(True)
+    Traceback (most recent call last):
+    ...
+    TypeError: n_points must be a positive integer
+
+    >>> sample_unit_sphere(0)
+    Traceback (most recent call last):
+    ...
+    ValueError: n_points must be 1 or greater
+
     """
     if isinstance(n_points, (bool, np.bool_)) or not isinstance(
         n_points, (int, np.integer)
     ):
-        raise TypeError("n_points must be an integer")
+        raise TypeError("n_points must be a positive integer")
     if n_points < 1:
-        raise ValueError("n_points must be a positive integer")
+        raise ValueError("n_points must be 1 or greater")
 
     def _normalize(X):
         X = np.asarray(X, dtype=float)

--- a/nitransforms/analysis/utils.py
+++ b/nitransforms/analysis/utils.py
@@ -201,7 +201,7 @@ def displacements_within_mask(
     return np.linalg.norm(diffs, axis=-1)
 
 
-def euler_from_matrix(affine: np.ndarray, degrees: bool = True) -> np.ndarray:
+def euler_from_matrix(affine: np.ndarray, degrees: bool = False) -> np.ndarray:
     """Extract XYZ Euler angles from affine or rotation matrices using SciPy.
 
     Parameters
@@ -209,7 +209,7 @@ def euler_from_matrix(affine: np.ndarray, degrees: bool = True) -> np.ndarray:
     affine : :obj:`~numpy.ndarray`
         Array with shape (..., 4, 4) or (..., 3, 3).
     degrees : :obj:`bool`, optional
-        If True, return degrees; otherwise radians.
+        If :obj:`True`, return degrees; otherwise radians.
 
     Returns
     -------
@@ -233,13 +233,15 @@ def euler_from_matrix(affine: np.ndarray, degrees: bool = True) -> np.ndarray:
     return angles.reshape(*batch_shape, 3)
 
 
-def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    """Extract translation (mm) and rotation (degrees) parameters from an affine matrix.
+def extract_motion_parameters(affine: np.ndarray, degrees: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract translation (mm) and rotation parameters from an affine matrix.
 
     Parameters
     ----------
     affine : :obj:`~numpy.ndarray`
         The affine transformation matrix.
+    degrees : :obj:`bool`, optional
+        If :obj:`True`, return degrees; otherwise radians.
 
     Returns
     -------
@@ -248,7 +250,7 @@ def extract_motion_parameters(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarra
     """
 
     translation = affine[:3, 3]
-    rotation = euler_from_matrix(affine, degrees=True)
+    rotation = euler_from_matrix(affine, degrees=degrees)
     return *translation, *rotation
 
 

--- a/nitransforms/tests/conftest.py
+++ b/nitransforms/tests/conftest.py
@@ -1,0 +1,11 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def random_number_generator(request):
+    """Automatically set a fixed-seed random number generator for all tests."""
+    request.node.rng = np.random.default_rng(1234)

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -1,0 +1,156 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+import numpy as np
+import nibabel as nb
+import pytest
+
+import nitransforms as nt
+
+from nitransforms.analysis.utils import (
+    compute_fd_from_motion,
+    compute_fd_from_transform,
+    displacements_within_mask,
+    extract_motion_parameters,
+    identify_spikes,
+)
+
+
+@pytest.fixture
+def identity_affine():
+    return np.eye(4)
+
+
+@pytest.fixture
+def simple_mask_img(identity_affine):
+    # 3x3x3 mask with center voxel as 1, rest 0
+    data = np.zeros((3, 3, 3), dtype=np.uint8)
+    data[1, 1, 1] = 1
+    return nb.Nifti1Image(data, identity_affine)
+
+
+@pytest.fixture
+def translation_transform():
+    # Simple translation of (1, 2, 3) mm
+    return nt.linear.Affine(map=np.array([
+        [1, 0, 0, 1],
+        [0, 1, 0, 2],
+        [0, 0, 1, 3],
+        [0, 0, 0, 1],
+    ]))
+
+
+@pytest.fixture
+def rotation_transform():
+    # 90 degree rotation around z axis
+    angle = np.pi / 2
+    rot = np.array([
+        [np.cos(angle), -np.sin(angle), 0, 0],
+        [np.sin(angle), np.cos(angle), 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ])
+    return nt.linear.Affine(map=rot)
+
+
+@pytest.mark.parametrize(
+    "test_xfm, reference_xfm, expected",
+    [
+        (nt.linear.Affine(np.eye(4)), None, np.zeros(1)),
+        (nt.linear.Affine(np.array([
+            [1, 0, 0, 1],
+            [0, 1, 0, 2],
+            [0, 0, 1, 3],
+            [0, 0, 0, 1],
+        ])), None, [np.linalg.norm([1, 2, 3])]),
+        (nt.linear.Affine(np.array([
+            [1, 0, 0, 1],
+            [0, 1, 0, 2],
+            [0, 0, 1, 3],
+            [0, 0, 0, 1],
+        ])), nt.linear.Affine(np.eye(4)), [np.linalg.norm([1, 2, 3])]),
+    ],
+)
+def test_displacements_within_mask(simple_mask_img, test_xfm, reference_xfm, expected):
+    disp = displacements_within_mask(simple_mask_img, test_xfm, reference_xfm)
+    np.testing.assert_allclose(disp, expected)
+
+
+@pytest.mark.parametrize(
+    "test_xfm, expected",
+    [
+        (nt.linear.Affine(np.eye(4)), 0),
+        (nt.linear.Affine(np.array([
+            [1, 0, 0, 1],
+            [0, 1, 0, 2],
+            [0, 0, 1, 3],
+            [0, 0, 0, 1],
+        ])), np.linalg.norm([1, 2, 3])),
+    ],
+)
+def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
+    fd = compute_fd_from_transform(simple_mask_img, test_xfm)
+    assert np.isclose(fd, expected)
+
+
+@pytest.mark.parametrize(
+    "motion_params, radius, expected",
+    [
+        (np.zeros((5, 6)), 50, np.zeros(5)),  # 5 frames, 3 trans, 3 rot
+        (
+            np.array([
+                [0,0,0,0,0,0],
+                [2,0,0,0,0,0],  # 2mm translation in x at frame 1
+                [2,0,0,90,0,0],
+            ]),  # 90deg rotation in x at frame 2
+            50,
+            [0, 2, abs(np.deg2rad(90)) * 50]
+        ),  # First frame: 0, Second: translation 2mm, Third: rotation (pi/2)*50
+    ],
+)
+def test_compute_fd_from_motion(motion_params, radius, expected):
+    fd = compute_fd_from_motion(motion_params, radius=radius)
+    np.testing.assert_allclose(fd, expected, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "affine, expected_trans, expected_rot",
+    [
+        (np.eye(4) + np.array([[0,0,0,10],[0,0,0,15],[0,0,0,20],[0,0,0,0]]),  # translation only
+         [10, 15, 20], [0, 0, 0]),
+        (np.array([
+            [1, 0, 0, 0],
+            [0, np.cos(np.deg2rad(30)), -np.sin(np.deg2rad(30)), 0],
+            [0, np.sin(np.deg2rad(30)), np.cos(np.deg2rad(30)), 0],
+            [0, 0, 0, 1],  # rotation only
+        ]), [0, 0, 0], [30, 0, 0]),  # Only one rot will be close to 30
+    ],
+)
+def test_extract_motion_parameters(affine, expected_trans, expected_rot):
+    params = extract_motion_parameters(affine)
+    assert np.allclose(params[:3], expected_trans)
+    # For rotation case, at least one value close to 30
+    if np.any(np.abs(expected_rot)):
+        assert np.any(np.isclose(np.abs(params[3:]), 30, atol=1e-4))
+    else:
+        assert np.allclose(params[3:], expected_rot)
+
+
+def test_identify_spikes(request):
+    rng = request.node.rng
+
+    n_samples = 450
+
+    fd = rng.normal(0, 5, n_samples)
+    threshold = 2.0
+
+    expected_indices = np.asarray(
+        [5, 57, 85, 100, 127, 180, 191, 202, 335, 393, 409]
+    )
+    expected_mask = np.zeros(n_samples, dtype=bool)
+    expected_mask[expected_indices] = True
+
+    obtained_indices, obtained_mask = identify_spikes(fd, threshold=threshold)
+
+    assert np.array_equal(obtained_indices, expected_indices)
+    assert np.array_equal(obtained_mask, expected_mask)

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -4,6 +4,7 @@
 import numpy as np
 import nibabel as nb
 import pytest
+from scipy.spatial.transform import Rotation as R
 
 import nitransforms as nt
 
@@ -11,6 +12,7 @@ from nitransforms.analysis.utils import (
     compute_fd_from_motion,
     compute_fd_from_transform,
     displacements_within_mask,
+    euler_from_matrix,
     extract_motion_parameters,
 )
 
@@ -110,6 +112,19 @@ def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
 def test_compute_fd_from_motion(motion_params, radius, expected):
     fd = compute_fd_from_motion(motion_params, radius=radius)
     np.testing.assert_allclose(fd, expected, atol=1e-4)
+
+
+def test_euler_from_matrix_matches_scipy_xyz():
+    expected = np.array([
+        [10.0, -5.0, 2.0],
+        [0.0, 30.0, -45.0],
+    ])
+    mats = R.from_euler("xyz", expected, degrees=True).as_matrix()
+    aff = np.tile(np.eye(4), (2, 1, 1))
+    aff[:, :3, :3] = mats
+
+    obtained = euler_from_matrix(aff, degrees=True)
+    assert np.allclose(obtained, expected, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -90,7 +90,7 @@ def test_displacements_within_mask(simple_mask_img, test_xfm, reference_xfm, exp
 )
 def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
     fd = compute_fd_from_transform(simple_mask_img, test_xfm)
-    assert np.isclose(fd, expected)
+    assert np.isclose(fd, expected, atol=1e-4, rtol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -77,6 +77,13 @@ def test_displacements_within_mask(simple_mask_img, test_xfm, reference_xfm, exp
     np.testing.assert_allclose(disp, expected)
 
 
+def test_compute_fd_from_transform_exceptions():
+    img = nb.Nifti1Image(np.zeros((5, 5, 5), dtype=float), np.eye(4))
+    xfm = nt.linear.Affine(np.eye(4))
+    with pytest.raises(ValueError, match=r"n_vertices must be >= 1"):
+        compute_fd_from_transform(img=img, xfm=xfm, n_vertices=0)
+
+
 @pytest.mark.parametrize(
     "test_xfm, expected",
     [
@@ -94,7 +101,13 @@ def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
     assert np.isclose(fd, expected, atol=1e-4, rtol=1e-6)
 
 
-def test_single_vertex_fd_computation_variants():
+def test_compute_fd_from_motion_exceptions():
+    bad = np.zeros((10, 5), dtype=float)  # must be (T, 6)
+    with pytest.raises(ValueError, match=r"motion_parameters must have shape \(T, 6\)\."):
+        compute_fd_from_motion(bad)
+
+
+def test_compute_fd_from_motion_single_vertex_variants():
     """For n_vertices=1, FD equals the L1 displacement of the single sampled point."""
     radius = 50.0
 
@@ -146,6 +159,38 @@ def test_single_vertex_fd_computation_variants():
 def test_compute_fd_from_motion(motion_params, radius, expected):
     fd = compute_fd_from_motion(motion_params, radius=radius)
     np.testing.assert_allclose(fd, expected, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 2),        # square but invalid
+        (3, 4),        # rectangular
+        (4, 3),        # rectangular
+        (5, 5),        # wrong square size
+        (1, 3, 4),     # last dims (3,4)
+        (2, 4, 3),     # last dims (4,3)
+        (2, 3, 3, 4),  # last dims (3,4)
+        (2, 4, 4, 3),  # last dims (4,3)
+    ],
+)
+def test_euler_from_matrix_exceptions(shape):
+    bad = np.zeros(shape, dtype=float)
+    with pytest.raises(
+        ValueError,
+        match=r"affine must end with shape \(3, 3\) or \(4, 4\)\.",
+    ):
+        euler_from_matrix(bad)
+
+
+@pytest.mark.parametrize("shape", [(3, 3), (4, 4), (7, 3, 3), (5, 4, 4)])
+def test_euler_from_matrix_valid_shapes(shape):
+    good = np.eye(shape[-1], dtype=float)
+    if len(shape) > 2:
+        good = np.broadcast_to(good, shape).copy()
+
+    out = euler_from_matrix(good)
+    assert out.shape == shape[:-2] + (3,)
 
 
 def test_euler_from_matrix_matches_scipy_xyz():

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -1,6 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
+import re
+
 import numpy as np
 import nibabel as nb
 import pytest
@@ -9,12 +11,25 @@ from scipy.spatial.transform import Rotation as R
 import nitransforms as nt
 
 from nitransforms.analysis.utils import (
+    AFFINE_SHAPE_ERROR,
+    AFFINE_SEQ_SHAPE_ERROR,
+    AFFINE_TYPE_ERROR_MSG,
+    MOTION_FORMAT_AFNI,
+    MOTION_FORMAT_FSL,
+    MOTION_PARAMS_SHAPE_ERROR_MSG,
+    MOTION_PARAMS_FMT_ERROR_MSG,
+    MOTION_PARAMS_INST_ERROR_MSG,
+    ROTATIONS_SHAPE_ERROR_MSG,
+    TRANSLATIONS_ERROR_MSG,
+    MotionParameters,
+    affine_to_motion_params,
     compute_fd_from_motion,
     compute_fd_from_transform,
     displacements_within_mask,
-    euler_from_matrix,
     extract_motion_parameters,
+    motion_params_to_affine,
 )
+from nitransforms.linear import Affine, LinearTransformsMapping
 
 
 @pytest.fixture
@@ -52,6 +67,175 @@ def rotation_transform():
         [0, 0, 0, 1],
     ])
     return nt.linear.Affine(map=rot)
+
+
+@pytest.mark.parametrize(
+    "translations, rotations, match_msg",
+    [
+        (np.zeros((10, 6)), np.zeros((10, 3)), TRANSLATIONS_ERROR_MSG),
+        (np.zeros((10, 3)), np.zeros((10, 6)), ROTATIONS_SHAPE_ERROR_MSG),
+        (np.zeros((10,)), np.zeros((10, 3)), TRANSLATIONS_ERROR_MSG),
+        (np.zeros((10, 3)), np.zeros((10,)), ROTATIONS_SHAPE_ERROR_MSG),
+    ],
+)
+def test_motion_parameters_validation(translations, rotations, match_msg):
+    with pytest.raises(ValueError, match=re.escape(match_msg)):
+        MotionParameters(translations, rotations)
+
+
+def test_motion_parameters_creation():
+    t = np.zeros((10, 3))
+    r = np.ones((10, 3))
+    params = MotionParameters(t, r)
+
+    assert params.translations.shape == (10, 3)
+    assert params.rotations.shape == (10, 3)
+
+    # Test that it supports tuple unpacking
+    translations, rotations = params
+    assert np.array_equal(translations, t)
+    assert np.array_equal(rotations, r)
+
+
+def test_extract_motion_parameters_invalid_format():
+    arr = np.random.rand(5, 6)
+    fmt = "unknown_format"
+    with pytest.raises(
+        ValueError, match=re.escape(MOTION_PARAMS_FMT_ERROR_MSG.format(fmt=fmt))
+    ):
+        extract_motion_parameters(arr, fmt=fmt)
+
+
+@pytest.mark.parametrize(
+    "invalid_arr",
+    [
+        np.zeros((5, 5)),
+        np.zeros((5,)),
+        np.zeros((2, 3, 3)),
+    ],
+)
+def test_extract_motion_parameters_shape_validation(invalid_arr):
+    with pytest.raises(ValueError, match=re.escape(MOTION_PARAMS_SHAPE_ERROR_MSG)):
+        extract_motion_parameters(invalid_arr)
+
+
+@pytest.mark.parametrize(
+    "fmt, expected_conversion",
+    [
+        (None, lambda r: r),
+        (MOTION_FORMAT_FSL, lambda r: r),
+        (MOTION_FORMAT_AFNI, lambda r: np.deg2rad(r)),
+    ],
+)
+def test_extract_motion_parameters_fmt(fmt, expected_conversion):
+    arr = np.random.rand(10, 6)
+    translations_expected = arr[:, :3]
+    rotations_raw = arr[:, 3:]
+
+    params = extract_motion_parameters(arr, fmt=fmt)
+
+    assert isinstance(params, MotionParameters)
+    assert np.allclose(params.translations, translations_expected)
+    assert np.allclose(params.rotations, expected_conversion(rotations_raw))
+
+
+@pytest.mark.parametrize(
+    "invalid_input, expected_exception, expected_match",
+    [
+        (np.zeros((4,)), ValueError, AFFINE_SEQ_SHAPE_ERROR),
+        (np.zeros((3, 3)), ValueError, AFFINE_SHAPE_ERROR),
+        (np.zeros((2, 3, 3)), ValueError, AFFINE_SEQ_SHAPE_ERROR),
+        ("not_an_affine", TypeError, AFFINE_TYPE_ERROR_MSG),
+    ],
+)
+def test_affine_to_motion_params_validation(invalid_input, expected_exception, expected_match):
+    with pytest.raises(expected_exception, match=re.escape(expected_match)):
+        affine_to_motion_params(invalid_input)
+
+
+def test_motion_params_to_affine_type_error():
+    with pytest.raises(TypeError, match=MOTION_PARAMS_INST_ERROR_MSG):
+        motion_params_to_affine("not_motion_params")
+
+
+@pytest.mark.parametrize("num_frames", [1, 5])
+def test_affine_motion_params_roundtrip(num_frames):
+    # Create valid synthetic translations and pure rotations via euler angles
+    translations = np.random.uniform(-5.0, 5.0, size=(num_frames, 3))
+    rotations = np.random.uniform(-0.1, 0.1, size=(num_frames, 3))  # small angles
+
+    original_params = MotionParameters(translations=translations, rotations=rotations)
+
+    # Convert to mapping
+    mapping = motion_params_to_affine(original_params)
+    assert isinstance(mapping, LinearTransformsMapping)
+    assert len(mapping) == num_frames
+
+    # Convert back to motion parameters
+    # mapping.matrix returns the batch array of shape (T, 4, 4)
+    recovered_params = affine_to_motion_params(mapping.matrix)
+
+    assert np.allclose(recovered_params.translations, original_params.translations, atol=1e-5)
+    assert np.allclose(recovered_params.rotations, original_params.rotations, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_type",
+    [
+        ((4, 4), "ndarray"),
+        ((3, 4, 4), "ndarray"),
+        ((1, 4, 4), "ndarray"),
+        ((4, 4), "affine"),
+        ((3, 4, 4), "mapping"),
+    ],
+)
+def test_affine_to_motion_params_misc_data(input_shape, input_type):
+    if len(input_shape) == 2:
+        mat = np.eye(4)
+        mat[:3, 3] = [1.0, 2.0, 3.0]
+    else:
+        T = input_shape[0]
+        mat = np.tile(np.eye(4), (T, 1, 1))
+
+    if input_type == "ndarray":
+        affine_in = mat
+    elif input_type == "affine":
+        affine_in = Affine(mat)
+    elif input_type == "mapping":
+        affine_in = LinearTransformsMapping([Affine(m) for m in mat])
+
+    params = affine_to_motion_params(affine_in)
+
+    expected_T = input_shape[0] if len(input_shape) == 3 else 1
+    assert isinstance(params, MotionParameters)
+    assert params.translations.shape == (expected_T, 3)
+    assert params.rotations.shape == (expected_T, 3)
+
+
+@pytest.mark.parametrize(
+    "affine, expected_trans, expected_rot",
+    [
+        (np.eye(4) + np.array([[0,0,0,10],[0,0,0,15],[0,0,0,20],[0,0,0,0]]),  # translation only
+         [10, 15, 20], [0, 0, 0]),
+        (np.array([
+            [1, 0, 0, 0],
+            [0, np.cos(np.deg2rad(30)), -np.sin(np.deg2rad(30)), 0],
+            [0, np.sin(np.deg2rad(30)), np.cos(np.deg2rad(30)), 0],
+            [0, 0, 0, 1],  # rotation only
+        ]), [0, 0, 0], [np.deg2rad(30), 0, 0]),  # Only one rot will be close to 30
+    ],
+)
+def test_affine_to_motion_params(affine, expected_trans, expected_rot):
+    params = affine_to_motion_params(affine)
+
+    # Since single affine results in T=1, check the first row [0]
+    assert np.allclose(params.translations[0], expected_trans)
+
+    # For rotation case, verify the values
+    if np.any(np.abs(expected_rot)):
+        assert np.any(np.isclose(np.abs(params.rotations[0]), np.deg2rad(30), atol=1e-4))
+    else:
+        assert np.allclose(params.rotations[0], expected_rot)
 
 
 @pytest.mark.parametrize(
@@ -102,9 +286,9 @@ def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
 
 
 def test_compute_fd_from_motion_exceptions():
-    bad = np.zeros((10, 5), dtype=float)  # must be (T, 6)
-    with pytest.raises(ValueError, match=r"motion_parameters must have shape \(T, 6\)\."):
-        compute_fd_from_motion(bad)
+    arr = np.zeros((4, 4), dtype=float)
+    with pytest.raises(TypeError, match=MOTION_PARAMS_INST_ERROR_MSG):
+        compute_fd_from_motion(arr)
 
 
 def test_compute_fd_from_motion_single_vertex_variants():
@@ -112,17 +296,20 @@ def test_compute_fd_from_motion_single_vertex_variants():
     radius = 50.0
 
     # One-step motion parameters: [tx, ty, tz, rx, ry, rz] (deg)
-    motion = np.array([
+    motion_arr = np.array([
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         [1.0, -2.0, 0.5, 1.5, -0.5, 0.25],
     ])
 
+    # Convert raw array (with rotations in degrees) into MotionParameters
+    motion_params = extract_motion_parameters(motion_arr, fmt=MOTION_FORMAT_AFNI)
+
     # Expected from canonical function
-    fd_motion = compute_fd_from_motion(motion, radius=radius)[1]
+    fd_motion = compute_fd_from_motion(motion_params, radius=radius)[1]
 
     # Build matching transforms (prev identity, current from same params)
-    t = motion[1, :3]
-    r_deg = motion[1, 3:]
+    t = motion_arr[1, :3]
+    r_deg = motion_arr[1, 3:]
     rot = R.from_euler("xyz", r_deg, degrees=True).as_matrix()
 
     M_prev = np.eye(4)
@@ -142,7 +329,7 @@ def test_compute_fd_from_motion_single_vertex_variants():
 
 
 @pytest.mark.parametrize(
-    "motion_params, radius, expected",
+    "motion_arr, radius, expected",
     [
         (np.zeros((5, 6)), 50, np.zeros(5)),  # 5 frames, 3 trans, 3 rot
         (
@@ -156,74 +343,16 @@ def test_compute_fd_from_motion_single_vertex_variants():
         ),  # First frame: 0, Second: translation 2mm, Third: rotation (pi/2)*50
     ],
 )
-def test_compute_fd_from_motion(motion_params, radius, expected):
+def test_compute_fd_from_motion(motion_arr, radius, expected):
+    # Wrap with extract_parameters using AFNI format to handle
+    # degree-to-radian conversion
+    motion_params = extract_motion_parameters(motion_arr, fmt=MOTION_FORMAT_AFNI)
     fd = compute_fd_from_motion(motion_params, radius=radius)
+
+    # Verify output shape matches the expected number of frames
+    assert fd.shape == (len(expected),)
+    # Verify the initial frame has zero displacement
+    assert fd[0] == 0.0
+
+    # Comprehensive value check
     np.testing.assert_allclose(fd, expected, atol=1e-4)
-
-
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (2, 2),        # square but invalid
-        (3, 4),        # rectangular
-        (4, 3),        # rectangular
-        (5, 5),        # wrong square size
-        (1, 3, 4),     # last dims (3,4)
-        (2, 4, 3),     # last dims (4,3)
-        (2, 3, 3, 4),  # last dims (3,4)
-        (2, 4, 4, 3),  # last dims (4,3)
-    ],
-)
-def test_euler_from_matrix_exceptions(shape):
-    bad = np.zeros(shape, dtype=float)
-    with pytest.raises(
-        ValueError,
-        match=r"affine must end with shape \(3, 3\) or \(4, 4\)\.",
-    ):
-        euler_from_matrix(bad)
-
-
-@pytest.mark.parametrize("shape", [(3, 3), (4, 4), (7, 3, 3), (5, 4, 4)])
-def test_euler_from_matrix_valid_shapes(shape):
-    good = np.eye(shape[-1], dtype=float)
-    if len(shape) > 2:
-        good = np.broadcast_to(good, shape).copy()
-
-    out = euler_from_matrix(good)
-    assert out.shape == shape[:-2] + (3,)
-
-
-def test_euler_from_matrix_matches_scipy_xyz():
-    expected = np.array([
-        [10.0, -5.0, 2.0],
-        [0.0, 30.0, -45.0],
-    ])
-    mats = R.from_euler("xyz", expected, degrees=True).as_matrix()
-    aff = np.tile(np.eye(4), (2, 1, 1))
-    aff[:, :3, :3] = mats
-
-    obtained = euler_from_matrix(aff, degrees=True)
-    assert np.allclose(obtained, expected, atol=1e-6)
-
-
-@pytest.mark.parametrize(
-    "affine, expected_trans, expected_rot",
-    [
-        (np.eye(4) + np.array([[0,0,0,10],[0,0,0,15],[0,0,0,20],[0,0,0,0]]),  # translation only
-         [10, 15, 20], [0, 0, 0]),
-        (np.array([
-            [1, 0, 0, 0],
-            [0, np.cos(np.deg2rad(30)), -np.sin(np.deg2rad(30)), 0],
-            [0, np.sin(np.deg2rad(30)), np.cos(np.deg2rad(30)), 0],
-            [0, 0, 0, 1],  # rotation only
-        ]), [0, 0, 0], [np.deg2rad(30), 0, 0]),  # Only one rot will be close to 30
-    ],
-)
-def test_extract_motion_parameters(affine, expected_trans, expected_rot):
-    params = extract_motion_parameters(affine)
-    assert np.allclose(params[:3], expected_trans)
-    # For rotation case, at least one value close to 30
-    if np.any(np.abs(expected_rot)):
-        assert np.any(np.isclose(np.abs(params[3:]), np.deg2rad(30), atol=1e-4))
-    else:
-        assert np.allclose(params[3:], expected_rot)

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -94,6 +94,40 @@ def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):
     assert np.isclose(fd, expected, atol=1e-4, rtol=1e-6)
 
 
+def test_single_vertex_fd_computation_variants():
+    """For n_vertices=1, FD equals the L1 displacement of the single sampled point."""
+    radius = 50.0
+
+    # One-step motion parameters: [tx, ty, tz, rx, ry, rz] (deg)
+    motion = np.array([
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, -2.0, 0.5, 1.5, -0.5, 0.25],
+    ])
+
+    # Expected from canonical function
+    fd_motion = compute_fd_from_motion(motion, radius=radius)[1]
+
+    # Build matching transforms (prev identity, current from same params)
+    t = motion[1, :3]
+    r_deg = motion[1, 3:]
+    rot = R.from_euler("xyz", r_deg, degrees=True).as_matrix()
+
+    M_prev = np.eye(4)
+    M_curr = np.eye(4)
+    M_curr[:3, :3] = rot
+    M_curr[:3, 3] = t
+
+    xfm_prev = nt.linear.Affine(M_prev)
+    xfm = nt.linear.Affine(M_curr)
+
+    img = nb.Nifti1Image(np.zeros((5, 5, 5), dtype=np.float32), np.eye(4))
+    fd_xfm = compute_fd_from_transform(
+        img, xfm, xfm_prev=xfm_prev, radius=radius, n_vertices=1
+    )
+
+    assert np.isclose(fd_xfm, fd_motion, atol=1e-6)
+
+
 @pytest.mark.parametrize(
     "motion_params, radius, expected",
     [

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -86,7 +86,7 @@ def test_displacements_within_mask(simple_mask_img, test_xfm, reference_xfm, exp
             [0, 1, 0, 2],
             [0, 0, 1, 3],
             [0, 0, 0, 1],
-        ])), np.linalg.norm([1, 2, 3])),
+        ])), np.linalg.norm([1, 2, 3], ord=1)),  # L1 norm of translation displacement
     ],
 )
 def test_compute_fd_from_transform(simple_mask_img, test_xfm, expected):

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -142,7 +142,7 @@ def test_identify_spikes(request):
     n_samples = 450
 
     fd = rng.normal(0, 5, n_samples)
-    threshold = 2.0
+    z_threshold = 2.0
 
     expected_indices = np.asarray(
         [5, 57, 85, 100, 127, 180, 191, 202, 335, 393, 409]
@@ -150,7 +150,7 @@ def test_identify_spikes(request):
     expected_mask = np.zeros(n_samples, dtype=bool)
     expected_mask[expected_indices] = True
 
-    obtained_indices, obtained_mask = identify_spikes(fd, threshold=threshold)
+    obtained_indices, obtained_mask = identify_spikes(fd, z_threshold=z_threshold)
 
     assert np.array_equal(obtained_indices, expected_indices)
     assert np.array_equal(obtained_mask, expected_mask)

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -12,7 +12,6 @@ from nitransforms.analysis.utils import (
     compute_fd_from_transform,
     displacements_within_mask,
     extract_motion_parameters,
-    identify_spikes,
 )
 
 
@@ -134,23 +133,3 @@ def test_extract_motion_parameters(affine, expected_trans, expected_rot):
         assert np.any(np.isclose(np.abs(params[3:]), 30, atol=1e-4))
     else:
         assert np.allclose(params[3:], expected_rot)
-
-
-def test_identify_spikes(request):
-    rng = request.node.rng
-
-    n_samples = 450
-
-    fd = rng.normal(0, 5, n_samples)
-    z_threshold = 2.0
-
-    expected_indices = np.asarray(
-        [5, 57, 85, 100, 127, 180, 191, 202, 335, 393, 409]
-    )
-    expected_mask = np.zeros(n_samples, dtype=bool)
-    expected_mask[expected_indices] = True
-
-    obtained_indices, obtained_mask = identify_spikes(fd, z_threshold=z_threshold)
-
-    assert np.array_equal(obtained_indices, expected_indices)
-    assert np.array_equal(obtained_mask, expected_mask)

--- a/nitransforms/tests/test_analysis.py
+++ b/nitransforms/tests/test_analysis.py
@@ -216,7 +216,7 @@ def test_euler_from_matrix_matches_scipy_xyz():
             [0, np.cos(np.deg2rad(30)), -np.sin(np.deg2rad(30)), 0],
             [0, np.sin(np.deg2rad(30)), np.cos(np.deg2rad(30)), 0],
             [0, 0, 0, 1],  # rotation only
-        ]), [0, 0, 0], [30, 0, 0]),  # Only one rot will be close to 30
+        ]), [0, 0, 0], [np.deg2rad(30), 0, 0]),  # Only one rot will be close to 30
     ],
 )
 def test_extract_motion_parameters(affine, expected_trans, expected_rot):
@@ -224,6 +224,6 @@ def test_extract_motion_parameters(affine, expected_trans, expected_rot):
     assert np.allclose(params[:3], expected_trans)
     # For rotation case, at least one value close to 30
     if np.any(np.abs(expected_rot)):
-        assert np.any(np.isclose(np.abs(params[3:]), 30, atol=1e-4))
+        assert np.any(np.isclose(np.abs(params[3:]), np.deg2rad(30), atol=1e-4))
     else:
         assert np.allclose(params[3:], expected_rot)


### PR DESCRIPTION
Add transform analysis utils.

Transfer contents from the `NiFreeze` projects so that hey can be reused across projects requiring transform analysis:
https://github.com/nipreps/nifreeze/blob/d27ba7552bbd9095c3c13b46443d87a4b5504c4c/src/nifreeze/analysis/motion.py https://github.com/nipreps/nifreeze/blob/d27ba7552bbd9095c3c13b46443d87a4b5504c4c/src/nifreeze/data/utils.py

Add a fixture to be able to reuse a random number generator across tests.

Fixes #239.